### PR TITLE
Fix(server): Resolve ReferenceError on simulation start

### DIFF
--- a/frontend/format.js
+++ b/frontend/format.js
@@ -5,7 +5,9 @@
  * @returns {string} The formatted string with units.
  */
 export default function formatUnits(value, type) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  const floatValue = parseFloat(value);
+
+  if (isNaN(floatValue) || !isFinite(floatValue)) {
     return '-';
   }
 
@@ -28,14 +30,14 @@ export default function formatUnits(value, type) {
 
   const scale = scales[type];
   if (!scale) {
-    return `${value.toFixed(2)}`;
+    return `${floatValue.toFixed(2)}`;
   }
 
   for (const { limit, divisor, unit } of scale) {
-    if (value >= limit) {
-      return `${(value / divisor).toFixed(2)} ${unit}`;
+    if (floatValue >= limit) {
+      return `${(floatValue / divisor).toFixed(2)} ${unit}`;
     }
   }
 
-  return `${value.toFixed(2)}`;
+  return `${floatValue.toFixed(2)}`;
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -32,6 +32,7 @@ let simulationState = {
   intervalId: null,
   status: 'stopped', // 'running', 'paused'
   tickCounter: 0,
+  zones: [],
 };
 
 const speedPresets = {
@@ -171,6 +172,7 @@ app.post('/simulation/start', async (req, res) => {
 
   try {
     const { structure, costEngine, rng, tickMachineLogic } = await initializeSimulation(savegame, difficulty);
+    const allZones = structure.rooms.flatMap(r => r.zones);
 
     simulationState = {
       ...simulationState,
@@ -180,6 +182,7 @@ app.post('/simulation/start', async (req, res) => {
       tickMachineLogic,
       status: 'running',
       tickCounter: 0,
+      zones: allZones,
     };
 
     const ticksPerSimDay = 24 / structure.rooms[0].zones[0].tickLengthInHours;
@@ -196,7 +199,7 @@ app.post('/simulation/start', async (req, res) => {
 
     simulationState.intervalId = setInterval(tickHandler, tickIntervalMs);
 
-    res.status(200).send({ message: `Simulation started with preset: ${preset}, found ${zones.length} zones.` });
+    res.status(200).send({ message: `Simulation started with preset: ${preset}, found ${allZones.length} zones.` });
   } catch (err) {
     logger.error({ err }, 'Error starting simulation');
     res.status(500).send({ message: 'Failed to start simulation.' });


### PR DESCRIPTION
The `zones` variable was not defined in the `/simulation/start` endpoint, causing a `ReferenceError` when the simulation was initiated.

This commit fixes the issue by:
- Calculating an `allZones` array from the `structure` object.
- Adding the `zones` array to the `simulationState` object for consistency and use in other parts of the application (e.g., `runDayAsBatch`).
- Using the correctly scoped `allZones` variable in the success response.

Fix(frontend): Make formatUnits tolerant to string inputs

The `formatUnits` function in `frontend/format.js` was intolerant and would not correctly format numeric values passed as strings.

This commit modifies the function to use `parseFloat()` to parse the input value, ensuring that both numbers and string-formatted numbers are handled correctly.