### PR TITLE
feat: Implement automatic rent calculation

### DIFF
--- a/data/config/difficulty.json
+++ b/data/config/difficulty.json
@@ -13,7 +13,9 @@
       "economics": {
         "initialCapital": 20000,
         "itemPriceMultiplier": 0.9,
-        "harvestPriceMultiplier": 1.1
+        "harvestPriceMultiplier": 1.1,
+        "rentPerSqmStructurePerTick": 0.1,
+        "rentPerSqmRoomPerTick": 0.2
       }
     }
   },
@@ -31,7 +33,9 @@
       "economics": {
         "initialCapital": 15000,
         "itemPriceMultiplier": 1.0,
-        "harvestPriceMultiplier": 1.0
+        "harvestPriceMultiplier": 1.0,
+        "rentPerSqmStructurePerTick": 0.15,
+        "rentPerSqmRoomPerTick": 0.3
       }
     }
   },
@@ -49,7 +53,9 @@
       "economics": {
         "initialCapital": 10000,
         "itemPriceMultiplier": 1.1,
-        "harvestPriceMultiplier": 0.9
+        "harvestPriceMultiplier": 0.9,
+        "rentPerSqmStructurePerTick": 0.2,
+        "rentPerSqmRoomPerTick": 0.4
       }
     }
   }

--- a/src/engine/CostEngine.js
+++ b/src/engine/CostEngine.js
@@ -22,6 +22,8 @@ export class CostEngine {
     initialCapital = 0,
     itemPriceMultiplier = 1.0,
     harvestPriceMultiplier = 1.0,
+    rentPerSqmStructurePerTick = 0,
+    rentPerSqmRoomPerTick = 0,
     keepEntries = false
   } = {}) {
     this.devicePriceMap = devicePriceMap;
@@ -33,6 +35,8 @@ export class CostEngine {
     this.pricePerMgK = Number(pricePerMgK) || 0;
     this.itemPriceMultiplier = Number(itemPriceMultiplier) || 1.0;
     this.harvestPriceMultiplier = Number(harvestPriceMultiplier) || 1.0;
+    this.rentPerSqmStructurePerTick = Number(rentPerSqmStructurePerTick) || 0;
+    this.rentPerSqmRoomPerTick = Number(rentPerSqmRoomPerTick) || 0;
     this.keepEntries = !!keepEntries;
 
     // 💰 Current balance (incl. initial capital)


### PR DESCRIPTION
Adds a recurring rent cost for structures and rooms to the simulation.

- Introduces `rentPerSqmStructurePerTick` and `rentPerSqmRoomPerTick` to the economic difficulty settings in `data/config/difficulty.json`.
- Updates the `CostEngine` to accept and utilize these new rent parameters.
- Modifies the main simulation loop (`_runSimulationTick` in `src/server/index.js`) to calculate and book rent expenses for the main structure and all rooms on every tick.
- Includes necessary refactoring in the server code to align with the hierarchical data model (structure -> rooms -> zones) required for the feature.