### PR TITLE
Track seed costs when planting and replanting

### DIFF
--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -146,6 +146,9 @@ export class Zone {
   addPlant(plant) {
     if (!plant) return;
     this.plants.push(plant);
+    if (this.costEngine && plant?.strain?.id) {
+      this.costEngine.bookSeeds(plant.strain.id, 1);
+    }
   }
 
   // --- Private Tick-Phase Implementations ---------------------------------
@@ -219,6 +222,7 @@ export class Zone {
           this.costEngine.bookRevenue('Harvest', revenue);
           this.logger.info({ plantId: plant.id.slice(0,8), yieldGrams: yieldGrams.toFixed(2), revenue: revenue.toFixed(2) }, 'HARVEST');
         }
+        this.costEngine.bookSeeds(strainId, 1);
 
         const newPlant = new Plant({
           strain: plant.strain,

--- a/tests/seedCosts.test.js
+++ b/tests/seedCosts.test.js
@@ -1,0 +1,45 @@
+import { Zone } from '../src/engine/Zone.js';
+import { Plant } from '../src/engine/Plant.js';
+import { CostEngine } from '../src/engine/CostEngine.js';
+import { createRng } from '../src/lib/rng.js';
+
+describe('Seed cost booking', () => {
+  it('books seed cost when adding new plant', () => {
+    const strainId = 'strain1';
+    const costEngine = new CostEngine({
+      strainPriceMap: new Map([[strainId, { seedPrice: 3 }]]),
+      keepEntries: true,
+    });
+    costEngine.startTick(1);
+    const zone = new Zone({ id: 'z1', runtime: { costEngine } });
+    const plant = new Plant({ strain: { id: strainId } });
+    zone.addPlant(plant);
+    const seedEntries = costEngine.ledger.entries.filter(e => e.meta?.subType === 'seeds');
+    expect(seedEntries.length).toBe(1);
+    expect(seedEntries[0].meta.strainId).toBe(strainId);
+    expect(costEngine.ledger.otherExpenseEUR).toBeCloseTo(3);
+  });
+
+  it('books seed cost on replant after harvest', () => {
+    const strainId = 'strain1';
+    const strainPriceMap = new Map([[strainId, { seedPrice: 2, harvestPricePerGram: 0 }]]);
+    const costEngine = new CostEngine({ strainPriceMap, keepEntries: true });
+    const rng = createRng('test');
+    const zone = new Zone({ id: 'z1', runtime: { costEngine, rng, strainPriceMap } });
+
+    // Initial plant already at harvest stage
+    const plant = new Plant({ strain: { id: strainId }, stage: 'harvestReady', method: {} });
+    costEngine.startTick(1);
+    zone.addPlant(plant);
+    costEngine.commitTick();
+
+    // Harvest and replant in new tick
+    costEngine.startTick(2);
+    zone.harvestAndInventory();
+
+    const seedEntries = costEngine.ledger.entries.filter(e => e.meta?.subType === 'seeds');
+    expect(seedEntries.length).toBe(1);
+    expect(seedEntries[0].meta.strainId).toBe(strainId);
+    expect(costEngine.ledger.otherExpenseEUR).toBeCloseTo(2);
+  });
+});


### PR DESCRIPTION
## Summary
- book seed expenses when plants are added to zones
- record seed costs again when plants are replanted after harvest
- add tests ensuring seed expenses appear in the ledger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee3509c24832597372280fc265255