### PR TITLE
Book device capex during setup

### DIFF
--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -29,7 +29,7 @@ function findBlueprint(blueprints, query = {}) {
     return candidates[0] ?? null;
 }
 
-function addDeviceN(zone, blueprint, count, runtimeCtx, overrides = {}) {
+export function addDeviceN(zone, blueprint, count, runtimeCtx, overrides = {}) {
     if (!blueprint) {
       logger.warn({ overrides }, 'addDeviceN: blueprint not found');
       return [];
@@ -46,6 +46,11 @@ function addDeviceN(zone, blueprint, count, runtimeCtx, overrides = {}) {
       inst.blueprintId = inst.blueprintId ?? clone.blueprintId;
       zone.addDevice?.(inst);
       out.push(inst);
+    }
+
+    const costEngine = zone?.costEngine ?? runtimeCtx?.costEngine;
+    if (costEngine) {
+      costEngine.bookCapex(blueprint.id, n, { zoneId: zone.id });
     }
     return out;
 }

--- a/tests/deviceCapex.test.js
+++ b/tests/deviceCapex.test.js
@@ -1,0 +1,33 @@
+import { Zone } from '../src/engine/Zone.js';
+import { CostEngine } from '../src/engine/CostEngine.js';
+import { addDeviceN } from '../src/sim/simulation.js';
+
+describe('Device CapEx booking', () => {
+  it('books capex once per device batch and updates opening balance', () => {
+    const deviceId = 'co2-01';
+    const price = 220;
+    const initialCapital = 1000;
+    const costEngine = new CostEngine({
+      devicePriceMap: new Map([[deviceId, { capitalExpenditure: price }]]),
+      initialCapital,
+      keepEntries: true,
+    });
+    const logger = {};
+    logger.child = () => logger;
+    const zone = new Zone({ id: 'z1', runtime: { costEngine, logger } });
+    const blueprint = { id: deviceId, kind: 'CO2Injector', name: 'CO2 Pulse', settings: {} };
+
+    costEngine.startTick(0);
+    addDeviceN(zone, blueprint, 2, {});
+    const entries = costEngine.ledger.entries.filter(e => e.type === 'capex');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].meta).toMatchObject({ deviceId, qty: 2, zoneId: 'z1' });
+    costEngine.commitTick();
+
+    expect(zone.devices).toHaveLength(2);
+
+    const expectedBalance = initialCapital - price * 2;
+    costEngine.startTick(1);
+    expect(costEngine.ledger.openingBalanceEUR).toBeCloseTo(expectedBalance);
+  });
+});


### PR DESCRIPTION
## Summary
- Record device capital expenditures when devices are added during simulation setup
- Export addDeviceN helper and ensure capex is booked once per batch
- Add regression test verifying balance after device acquisition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee48753e08325b32b88c6ad993b4f