### PR TITLE
Track labor costs per tick

### DIFF
--- a/data/savegames/default.json
+++ b/data/savegames/default.json
@@ -4,7 +4,8 @@
   "costEngine": {
     "initialCapital": 25000,
     "energyPricePerKWh": 0.30,
-    "keepEntries": true
+    "keepEntries": true,
+    "wagePerTick": 10
   },
   "structure": {
     "id": "main_building_01",

--- a/src/engine/CostEngine.js
+++ b/src/engine/CostEngine.js
@@ -24,6 +24,7 @@ export class CostEngine {
     harvestPriceMultiplier = 1.0,
     rentPerSqmStructurePerTick = 0,
     rentPerSqmRoomPerTick = 0,
+    wagePerTick = 0,
     keepEntries = false
   } = {}) {
     this.devicePriceMap = devicePriceMap;
@@ -37,6 +38,7 @@ export class CostEngine {
     this.harvestPriceMultiplier = Number(harvestPriceMultiplier) || 1.0;
     this.rentPerSqmStructurePerTick = Number(rentPerSqmStructurePerTick) || 0;
     this.rentPerSqmRoomPerTick = Number(rentPerSqmRoomPerTick) || 0;
+    this.wagePerTick = Number(wagePerTick) || 0;
     this.keepEntries = !!keepEntries;
 
     // 💰 Current balance (incl. initial capital)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -54,6 +54,11 @@ async function _runSimulationTick() {
   const absoluteTick = (costEngine._tickCounter || 0) + 1;
   costEngine.startTick(absoluteTick);
 
+  const wagePerTick = costEngine.wagePerTick;
+  if (wagePerTick > 0) {
+    costEngine.bookExpense('Labor', wagePerTick);
+  }
+
   // --- Rent Calculation ---
   const structureRent = structure.area * costEngine.rentPerSqmStructurePerTick;
   if (structureRent > 0) {

--- a/tests/wageCosts.test.js
+++ b/tests/wageCosts.test.js
@@ -1,0 +1,24 @@
+import { CostEngine } from '../src/engine/CostEngine.js';
+import { initializeSimulation } from '../src/sim/simulation.js';
+
+describe('Labor cost booking', () => {
+  it('deducts wagePerTick each tick', () => {
+    const wagePerTick = 25;
+    const initialCapital = 100;
+    const costEngine = new CostEngine({ initialCapital, wagePerTick, keepEntries: true });
+
+    costEngine.startTick(1);
+    costEngine.bookExpense('Labor', costEngine.wagePerTick);
+    const totals = costEngine.commitTick();
+
+    expect(totals.totalExpensesEUR).toBeCloseTo(wagePerTick);
+    expect(costEngine.getBalance()).toBeCloseTo(initialCapital - wagePerTick);
+    const grandTotals = costEngine.getGrandTotals();
+    expect(grandTotals.totalOtherExpenseEUR).toBeCloseTo(wagePerTick);
+  });
+
+  it('loads wagePerTick from savegame configuration', async () => {
+    const { costEngine } = await initializeSimulation('default');
+    expect(costEngine.wagePerTick).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable `wagePerTick` to cost engine and default savegame
- record labor expense each simulation tick via `costEngine.bookExpense`
- cover wage deduction with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ee5fefffc83259ae1af0ddd98a338