### PR TITLE
Include water and fertilizer in zone cost reports

### DIFF
--- a/src/engine/CostEngine.js
+++ b/src/engine/CostEngine.js
@@ -333,6 +333,21 @@ export class CostEngine {
     return totals;
   }
 
+  getWaterAndFertilizerTotalsForZone(zoneId) {
+    if (!this.keepEntries || !this.ledger.entries) return { waterEUR: 0, fertilizerEUR: 0 };
+    const records = this.ledger.entries.filter(r => r.meta?.zoneId === zoneId);
+    let waterEUR = 0;
+    let fertilizerEUR = 0;
+    for (const record of records) {
+      if (record.type === 'water') {
+        waterEUR += record.eur;
+      } else if (record.type === 'fertilizer') {
+        fertilizerEUR += record.eur;
+      }
+    }
+    return { waterEUR, fertilizerEUR };
+  }
+
   /** internal summation + optional entries tracking */
   _add(type, eur, meta) {
     const val = Number(eur) || 0;

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -361,14 +361,16 @@ export class Zone {
       });
     }
 
-    // In a real scenario, water/fertilizer would be tracked here too,
-    // but the current logic books them directly. We'll represent zone-level overhead as 0 for now.
+    const { waterEUR, fertilizerEUR } = this.costEngine.getWaterAndFertilizerTotalsForZone(this.id);
+
     const zoneOverhead = 0;
 
     return {
-      total: totalEnergyCost + totalMaintenanceCost + zoneOverhead,
+      total: totalEnergyCost + totalMaintenanceCost + waterEUR + fertilizerEUR + zoneOverhead,
       energy: totalEnergyCost,
       maintenance: totalMaintenanceCost,
+      water: waterEUR,
+      fertilizer: fertilizerEUR,
       other: zoneOverhead,
       devices: deviceCosts,
     };

--- a/tests/waterFertilizerCosts.test.js
+++ b/tests/waterFertilizerCosts.test.js
@@ -1,0 +1,16 @@
+import { Zone } from '../src/engine/Zone.js';
+import { CostEngine } from '../src/engine/CostEngine.js';
+
+test('Zone.getTickCosts includes water and fertilizer expenses', () => {
+  const costEngine = new CostEngine({ keepEntries: true });
+  costEngine.startTick(1);
+  const zone = new Zone({ id: 'z1', runtime: { costEngine } });
+  costEngine.bookWater(10, { zoneId: 'z1' });
+  costEngine.bookFertilizer({ N: 20, P: 10, K: 5 }, { zoneId: 'z1' });
+  const expectedWater = 10 * costEngine.waterPricePerLiter;
+  const expectedFertilizer = 20 * costEngine.pricePerMgN + 10 * costEngine.pricePerMgP + 5 * costEngine.pricePerMgK;
+  const costs = zone.getTickCosts(1);
+  expect(costs.water).toBeCloseTo(expectedWater);
+  expect(costs.fertilizer).toBeCloseTo(expectedFertilizer);
+  expect(costs.total).toBeCloseTo(expectedWater + expectedFertilizer);
+});


### PR DESCRIPTION
## Summary
- Add cost engine helper to sum water and fertilizer expenses per zone
- Include water and fertilizer totals in `Zone.getTickCosts` reports
- Test `Zone.getTickCosts` reflects water and fertilizer bookings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ee8803ae8832597aaf68958505d78