### PR TITLE
Expose numeric metrics and tick timing

### DIFF
--- a/frontend/format.js
+++ b/frontend/format.js
@@ -1,13 +1,16 @@
 /**
  * Formats a number into a more readable string with appropriate units.
- * @param {number} value The number to format.
+ * @param {number|string} value The number to format.
  * @param {'grams' | 'kWh' | 'liters'} type The type of unit.
  * @returns {string} The formatted string with units.
  */
 export default function formatUnits(value, type) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
     return '-';
   }
+
+  value = num;
 
   const scales = {
     grams: [

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -119,6 +119,14 @@
             <span class="label">Kontostand</span>
             <span class="value" id="balance-top">—</span>
           </div>
+          <div class="finance" title="Energie pro Tag">
+            <span class="label">Energie/Tag</span>
+            <span class="value" id="daily-energy">—</span>
+          </div>
+          <div class="finance" title="Wasser pro Tag">
+            <span class="label">Wasser/Tag</span>
+            <span class="value" id="daily-water">—</span>
+          </div>
         </div>
       </div>
 

--- a/frontend/main-new.js
+++ b/frontend/main-new.js
@@ -27,6 +27,8 @@ const state = {
     tickHours: 3,
     simTime: new Date(2025, 0, 1, 8, 0, 0),
     balance: 0,
+    dailyEnergyKWh: 0,
+    dailyWaterL: 0,
     structureData: { structures: [] },
 };
 
@@ -86,8 +88,10 @@ function updateWithLiveData(data) {
     console.log(JSON.stringify(data, null, 2));
     state.tick = data.tick;
     state.simTime = new Date(data.isoTime);
-    state.balance = data.balance;
-    state.tickHours = data.tickIntervalHours;
+    state.balance = Number(data.balance);
+    state.tickHours = Number(data.tickIntervalHours);
+    state.dailyEnergyKWh = Number(data.dailyEnergyKWh);
+    state.dailyWaterL = Number(data.dailyWaterL);
 
     // Update live data in the structure data
     if (data.zoneSummaries) {
@@ -268,9 +272,9 @@ function renderStructureContent(root) {
         const consumptionGrid = document.createElement('div');
         consumptionGrid.className = 'grid';
         consumptionGrid.style.marginBottom = '12px';
-        consumptionGrid.appendChild(card('Costs (Tick)', fmtEUR.format(r.totalExpensesEUR || 0)));
-        consumptionGrid.appendChild(card('Energy (Tick)', formatUnits(r.energyKWh || 0, 'kWh')));
-        consumptionGrid.appendChild(card('Water (Tick)', formatUnits(r.waterL || 0, 'liters')));
+        consumptionGrid.appendChild(card('Costs (Tick)', fmtEUR.format(Number(r.totalExpensesEUR) || 0)));
+        consumptionGrid.appendChild(card('Energy (Tick)', formatUnits(Number(r.energyKWh) || 0, 'kWh')));
+        consumptionGrid.appendChild(card('Water (Tick)', formatUnits(Number(r.waterL) || 0, 'liters')));
         // Insert after the header, before other content
         header.insertAdjacentElement('afterend', consumptionGrid);
     }
@@ -427,6 +431,8 @@ function renderTop() {
     txt("#time", state.simTime.toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" }));
     txt("#balance-top", fmtEUR.format(state.balance));
     txt("#tick-hours", state.tickHours);
+    txt("#daily-energy", formatUnits(state.dailyEnergyKWh, 'kWh'));
+    txt("#daily-water", formatUnits(state.dailyWaterL, 'liters'));
     const clock = $("#clock");
     if (clock) clock.classList.toggle("running", state.running);
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -133,8 +133,8 @@ function _broadcastStatusUpdate() {
       name: zone.name,
       strainName: p0.strain?.name,
       plantCount: zone.plants.length,
-      avgHealth: (avgHealth * 100).toFixed(0),
-      expectedYield: expectedYield.toFixed(2),
+      avgHealth: avgHealth * 100,
+      expectedYield,
       timeToHarvest: timeToHarvest,
       temperatureC: zone.status.temperatureC,
       humidity: zone.status.humidity,
@@ -155,11 +155,13 @@ function _broadcastStatusUpdate() {
     tick: absoluteTick,
     time: new Date(simulationState.tickCounter * tickLengthInHours * 60 * 60 * 1000).toISOString().substr(11, 8),
     day: Math.floor((simulationState.tickCounter * tickLengthInHours) / 24) + 1,
-    balance: (costEngine.getGrandTotals().finalBalanceEUR ?? 0).toFixed(2),
+    isoTime: new Date(simulationState.tickCounter * tickLengthInHours * 60 * 60 * 1000).toISOString(),
+    tickIntervalHours: tickLengthInHours,
+    balance: costEngine.getGrandTotals().finalBalanceEUR ?? 0,
     zoneSummaries, // Changed from zoneSummary
     roomSummaries,
-    dailyEnergyKWh: dailyEnergyKWh.toFixed(2),
-    dailyWaterL: dailyWaterL.toFixed(2),
+    dailyEnergyKWh,
+    dailyWaterL,
     ...tickTotals
   };
 
@@ -285,9 +287,10 @@ app.get('/simulation/status', (req, res) => {
   res.status(200).send({
     status,
     tick: tickCounter,
-    time: new Date(tickCounter * tickLengthInHours * 60 * 60 * 1000).toISOString().substr(11, 8),
+    isoTime: new Date(tickCounter * tickLengthInHours * 60 * 60 * 1000).toISOString(),
+    tickIntervalHours: tickLengthInHours,
     day: Math.floor((tickCounter * tickLengthInHours) / 24) + 1,
-    balance: (costEngine.getGrandTotals().finalBalanceEUR ?? 0).toFixed(2),
+    balance: costEngine.getGrandTotals().finalBalanceEUR ?? 0,
     structure: structure
   });
 });

--- a/src/server/services/zoneOverviewService.js
+++ b/src/server/services/zoneOverviewService.js
@@ -47,7 +47,7 @@ export function createZoneOverviewDTO(zone, costEngine) {
         },
         predictions: {
             harvestEtaDays,
-            yieldForecastGrams: yieldForecastGrams.toFixed(1),
+            yieldForecastGrams,
         },
         environment: {
             temperature: { set: 24, actual: zone.status.temperatureC, delta: 0, stability: 0 }, // TODO
@@ -108,7 +108,7 @@ export function createZoneOverviewDTO(zone, costEngine) {
             const biomassIndex = Math.round((avgBiomass / (pkg.plants[0].strain.maxBiomass || 500)) * 100);
 
             delete pkg.plants; // Don't need to send the full plant objects
-            return { ...pkg, avgAgeDays: avgAgeDays.toFixed(1), avgHealth: (avgHealth * 100).toFixed(0), biomassIndex };
+            return { ...pkg, avgAgeDays, avgHealth: avgHealth * 100, biomassIndex };
         }),
         alerts: [], // TODO
         actions: [], // TODO


### PR DESCRIPTION
## Summary
- send raw numbers for health, yield, balance and daily resource metrics
- add ISO timestamp and tick interval to simulation status
- surface daily energy and water use in UI and room KPIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eeba7319c8325be43e05ff7e9f48b