### PR TITLE
Add company overview and consumption stats

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,7 +91,7 @@
       <div class="brand"><div class="logo"></div><h1>Weed Breed</h1></div>
       <div class="ribbon" role="tablist" aria-label="Tree Auswahl">
         <button class="rbtn" id="rb-structure" data-mode="structure" aria-pressed="true">🏗️ Structure</button>
-        <button class="rbtn" id="rb-finance" data-mode="finance" aria-pressed="false">💶 Finance</button>
+        <button class="rbtn" id="rb-company" data-mode="company" aria-pressed="false">🏢 Company</button>
         <button class="rbtn" id="rb-shop" data-mode="shop" aria-pressed="false">🛒 Shop</button>
       </div>
       <ul class="tree" id="tree" role="tree" aria-label="Explorer"><!-- built by JS --></ul>

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -162,7 +162,8 @@ function _broadcastStatusUpdate() {
     roomSummaries,
     dailyEnergyKWh,
     dailyWaterL,
-    ...tickTotals
+    ...tickTotals,
+    grandTotals: costEngine.getGrandTotals()
   };
 
   logger.info({ tick: absoluteTick, zones: zoneSummaries.length }, 'Broadcasting update to clients');
@@ -291,7 +292,8 @@ app.get('/simulation/status', (req, res) => {
     tickIntervalHours: tickLengthInHours,
     day: Math.floor((tickCounter * tickLengthInHours) / 24) + 1,
     balance: costEngine.getGrandTotals().finalBalanceEUR ?? 0,
-    structure: structure
+    structure: structure,
+    grandTotals: costEngine.getGrandTotals()
   });
 });
 


### PR DESCRIPTION
## Summary
- Track tick-level energy, water and costs, plus grand totals
- Add Company tree mode with financial overview
- Expose grand totals via server broadcast and status responses

## Testing
- `npm test`
- `curl http://localhost:3000/simulation/status | jq '.grandTotals'`


------
https://chatgpt.com/codex/tasks/task_e_689ef62c1f588325a8497bc923f64017