### PR TITLE
Move savegame loader into engine loaders

### DIFF
--- a/src/engine/loaders/savegameLoader.js
+++ b/src/engine/loaders/savegameLoader.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const savegamesDir = path.join(__dirname, '..', '..', 'data', 'savegames');
+const savegamesDir = path.join(__dirname, '..', '..', '..', 'data', 'savegames');
 
 /**
  * Loads and parses a savegame file.

--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -10,7 +10,7 @@ import { loadDevicePriceMap, loadStrainPriceMap } from '../engine/loaders/priceL
 import { CostEngine } from '../engine/CostEngine.js';
 import { createRng } from '../lib/rng.js';
 import { createTickMachine }from './tickMachine.js';
-import { loadSavegame } from '../server/savegameLoader.js';
+import { loadSavegame } from '../engine/loaders/savegameLoader.js';
 import { loadDifficultyConfig } from '../engine/loaders/difficultyLoader.js';
 
 // --- Loader-Wrapper ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- move savegame loader from server to engine loaders module
- update simulation import to use new engine path
- fix savegame loader path to data/savegames

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f03eaeb108325b7bc3d24ee639b63