### PR TITLE
Organize factories and loaders into dedicated folders

### DIFF
--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -2,7 +2,7 @@
 import { ensureEnv, resetEnvAggregates, getZoneVolume, clamp } from './deviceUtils.js';
 import { env, AIR_DENSITY, AIR_CP, TICK_HOURS_DEFAULT } from '../config/env.js';
 import { Plant } from './Plant.js';
-import { createDevice } from './deviceFactory.js';
+import { createDevice } from './factories/deviceFactory.js';
 
 /**
  * Zone

--- a/src/engine/factories/cultivationMethodFactory.js
+++ b/src/engine/factories/cultivationMethodFactory.js
@@ -1,4 +1,4 @@
-// src/engine/cultivationMethodFactory.js
+// src/engine/factories/cultivationMethodFactory.js
 // Baut ein Zonen-taugliches Objekt und kann die Kompatibilität mit einem Strain bewerten.
 
 function getByPath(obj, dotPath) {

--- a/src/engine/factories/deviceFactory.js
+++ b/src/engine/factories/deviceFactory.js
@@ -1,12 +1,12 @@
-// src/engine/deviceFactory.js
+// src/engine/factories/deviceFactory.js
 // Factory-Registry für eingebaute Geräte
 
-import { BaseDevice } from './BaseDevice.js';
-import { Lamp } from './devices/Lamp.js';
-import { ClimateUnit } from './devices/ClimateUnit.js';
-import { Dehumidifier } from './devices/Dehumidifier.js';
-import { CO2Injector } from './devices/CO2Injector.js';
-import { HumidityControlUnit } from './devices/HumidityControlUnit.js';
+import { BaseDevice } from '../BaseDevice.js';
+import { Lamp } from '../devices/Lamp.js';
+import { ClimateUnit } from '../devices/ClimateUnit.js';
+import { Dehumidifier } from '../devices/Dehumidifier.js';
+import { CO2Injector } from '../devices/CO2Injector.js';
+import { HumidityControlUnit } from '../devices/HumidityControlUnit.js';
 
 const REGISTRY = {
   Lamp,

--- a/src/engine/factories/plantFactory.js
+++ b/src/engine/factories/plantFactory.js
@@ -1,9 +1,9 @@
-// src/engine/plantFactory.js
+// src/engine/factories/plantFactory.js
 // ESM - creates Plant states (or instances) from strain blueprints.
 // Prices (seed/harvest) are optionally mixed in from /data/config/strainPrices.json.
 
 import { randomUUID } from 'crypto';
-import { loadStrainBySlug, loadStrainById } from './strainLoader.js';
+import { loadStrainBySlug, loadStrainById } from '../loaders/strainLoader.js';
 
 /**
  * Creates an initial plant state from a strain object.

--- a/src/engine/loaders/cultivationMethodLoader.js
+++ b/src/engine/loaders/cultivationMethodLoader.js
@@ -1,4 +1,4 @@
-// src/engine/cultivationMethodLoader.js
+// src/engine/loaders/cultivationMethodLoader.js
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Datenordner: <root>/data/cultivationMethods/*.json
-const METHODS_DIR = path.resolve(__dirname, '../../data/cultivationMethods');
+const METHODS_DIR = path.resolve(__dirname, '../../../data/cultivationMethods');
 
 async function readJson(fp) {
   const raw = await fs.readFile(fp, 'utf-8');

--- a/src/engine/loaders/deviceLoader.js
+++ b/src/engine/loaders/deviceLoader.js
@@ -1,4 +1,4 @@
-// src/engine/deviceLoader.js
+// src/engine/loaders/deviceLoader.js
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // <root>/data/devices/*.json
-const DEVICES_DIR = path.resolve(__dirname, '../../data/devices');
+const DEVICES_DIR = path.resolve(__dirname, '../../../data/devices');
 
 async function readJson(fp) {
   const raw = await fs.readFile(fp, 'utf-8');

--- a/src/engine/loaders/difficultyLoader.js
+++ b/src/engine/loaders/difficultyLoader.js
@@ -5,7 +5,15 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const difficultyConfigPath = path.join(__dirname, '..', '..', 'data', 'config', 'difficulty.json');
+const difficultyConfigPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'data',
+  'config',
+  'difficulty.json'
+);
 
 /**
  * Loads the difficulty settings from the configuration file.

--- a/src/engine/loaders/priceLoader.js
+++ b/src/engine/loaders/priceLoader.js
@@ -1,4 +1,4 @@
-// src/engine/priceLoader.js
+// src/engine/loaders/priceLoader.js
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Annahme: <root>/data/config/{devicePrices.json,strainPrices.json}
-const CONFIG_DIR = path.resolve(__dirname, '../../data/config');
+const CONFIG_DIR = path.resolve(__dirname, '../../../data/config');
 
 async function readJson(fp) {
   const raw = await fs.readFile(fp, 'utf-8');

--- a/src/engine/loaders/strainLoader.js
+++ b/src/engine/loaders/strainLoader.js
@@ -1,4 +1,4 @@
-// src/engine/strainLoader.js
+// src/engine/loaders/strainLoader.js
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Assumption: Project structure: <root>/src/engine/* and <root>/data/strains/*.json
-const STRAINS_DIR = path.resolve(__dirname, '../../data/strains');
+const STRAINS_DIR = path.resolve(__dirname, '../../../data/strains');
 
 async function readJson(fp) {
   const raw = await fs.readFile(fp, 'utf-8');

--- a/src/server/services/savegameLoader.js
+++ b/src/server/services/savegameLoader.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const savegamesDir = path.join(__dirname, '..', '..', 'data', 'savegames');
+const savegamesDir = path.join(__dirname, '..', '..', '..', 'data', 'savegames');
 
 /**
  * Loads and parses a savegame file.

--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -2,16 +2,16 @@ import { TICK_HOURS_DEFAULT } from '../config/env.js';
 import { Zone } from '../engine/Zone.js';
 import { Plant } from '../engine/Plant.js';
 import { logger } from '../lib/logger.js';
-import { createDevice } from '../engine/deviceFactory.js';
-import * as DeviceLoader from '../engine/deviceLoader.js';
-import { loadStrainBySlug } from '../engine/strainLoader.js';
-import { loadCultivationMethod } from '../engine/cultivationMethodLoader.js';
-import { loadDevicePriceMap, loadStrainPriceMap } from '../engine/priceLoader.js';
+import { createDevice } from '../engine/factories/deviceFactory.js';
+import * as DeviceLoader from '../engine/loaders/deviceLoader.js';
+import { loadStrainBySlug } from '../engine/loaders/strainLoader.js';
+import { loadCultivationMethod } from '../engine/loaders/cultivationMethodLoader.js';
+import { loadDevicePriceMap, loadStrainPriceMap } from '../engine/loaders/priceLoader.js';
 import { CostEngine } from '../engine/CostEngine.js';
 import { createRng } from '../lib/rng.js';
 import { createTickMachine }from './tickMachine.js';
-import { loadSavegame } from '../server/savegameLoader.js';
-import { loadDifficultyConfig } from '../engine/difficultyLoader.js';
+import { loadSavegame } from '../server/services/savegameLoader.js';
+import { loadDifficultyConfig } from '../engine/loaders/difficultyLoader.js';
 
 // --- Loader-Wrapper ---------------------------------------------------------
 async function getDeviceBlueprints() {


### PR DESCRIPTION
## Summary
- move factory modules under `src/engine/factories`
- group loader modules under `src/engine/loaders`
- relocate server `savegameLoader` into `src/server/services`
- update all module imports and path references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f070d44748325923a5cffef3952f6