### PR TITLE
Track photoperiod and resource costs

### DIFF
--- a/src/engine/CostEngine.js
+++ b/src/engine/CostEngine.js
@@ -16,6 +16,7 @@ export class CostEngine {
     strainPriceMap = new Map(),
     energyPricePerKWh = 0.35,
     waterPricePerLiter = 0.002, // 2 EUR/m³
+    pricePerPpmCO2 = 0,
     pricePerMgN = 0.001,
     pricePerMgP = 0.002,
     pricePerMgK = 0.0015,
@@ -30,6 +31,7 @@ export class CostEngine {
     this.strainPriceMap = strainPriceMap;
     this.energyPricePerKWh = Number(energyPricePerKWh) || 0;
     this.waterPricePerLiter = Number(waterPricePerLiter) || 0;
+    this.pricePerPpmCO2 = Number(pricePerPpmCO2) || 0;
     this.pricePerMgN = Number(pricePerMgN) || 0;
     this.pricePerMgP = Number(pricePerMgP) || 0;
     this.pricePerMgK = Number(pricePerMgK) || 0;
@@ -63,6 +65,7 @@ export class CostEngine {
       energyEUR: 0,
       energyKWh: 0,
       waterL: 0,
+      co2ppm: 0,
       maintenanceEUR: 0,
       capexEUR: 0,
       otherExpenseEUR: 0,
@@ -111,6 +114,16 @@ export class CostEngine {
     this.ledger.waterL += amountL;
     const eur = amountL * this.waterPricePerLiter;
     this._add('expense', eur, this.keepEntries ? { subType: 'water', liters: amountL, pricePerLiter: this.waterPricePerLiter } : undefined);
+  }
+
+  /** Book CO2 injection (ppm in the current tick) */
+  bookCO2(ppm) {
+    const amount = Number(ppm) || 0;
+    if (amount <= 0) return;
+
+    this.ledger.co2ppm += amount;
+    const eur = amount * this.pricePerPpmCO2;
+    this._add('expense', eur, this.keepEntries ? { subType: 'co2', ppm: amount, pricePerPpm: this.pricePerPpmCO2 } : undefined);
   }
 
   /** Book fertilizer consumption (in mg N, P, K) */
@@ -225,6 +238,7 @@ export class CostEngine {
       energyEUR: this.ledger.energyEUR,
       energyKWh: this.ledger.energyKWh,
       waterL: this.ledger.waterL,
+      co2ppm: this.ledger.co2ppm,
       maintenanceEUR: this.ledger.maintenanceEUR,
       capexEUR: this.ledger.capexEUR,
       otherExpenseEUR: this.ledger.otherExpenseEUR,
@@ -263,6 +277,7 @@ export class CostEngine {
       energyEUR: this.ledger.energyEUR,
       energyKWh: this.ledger.energyKWh,
       waterL: this.ledger.waterL,
+      co2ppm: this.ledger.co2ppm,
       maintenanceEUR: this.ledger.maintenanceEUR,
       capexEUR: this.ledger.capexEUR,
       otherExpenseEUR: this.ledger.otherExpenseEUR,

--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -104,8 +104,12 @@ export class Plant {
     const rhStress = Math.abs(RH - rhOpt) / (env.plant.rhWidth * optimalRangeMultiplier);
     if (rhStress > 0.1) this.stressors.humidity = { actual: RH, target: rhOpt };
 
-    const lStress = (L < lightPreferences[0] || L > lightPreferences[1]) ? 0.2 : 0;
-    if (lStress > 0) this.stressors.light = { actual: L, target: lightPreferences };
+    const lightsOn = zone?.runtime?.lightsOn !== false;
+    let lStress = 0;
+    if (lightsOn) {
+      lStress = (L < lightPreferences[0] || L > lightPreferences[1]) ? 0.2 : 0;
+      if (lStress > 0) this.stressors.light = { actual: L, target: lightPreferences };
+    }
 
     const envStress = Math.min(1, (tStress + rhStress + lStress) / 3);
 

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -164,6 +164,7 @@ export class Zone {
     const currentSimHour = (tickIndex * this.tickLengthInHours) % 24;
 
     const lightsOn = currentSimHour < lightHours;
+    this.runtime.lightsOn = lightsOn;
 
     for (const device of this.devices) {
       if (device.kind === 'Lamp') {
@@ -224,6 +225,9 @@ export class Zone {
           rng: this.rng
         });
         this.plants[i] = newPlant;
+        if (this.costEngine && strainId) {
+          this.costEngine.bookSeeds(strainId, 1);
+        }
         this.logger.info({ oldPlantId: plant.id.slice(0,8), newPlantId: newPlant.id.slice(0,8) }, 'REPLANT');
       }
     }

--- a/src/engine/devices/CO2Injector.js
+++ b/src/engine/devices/CO2Injector.js
@@ -21,7 +21,11 @@ export class CO2Injector extends BaseDevice {
     if (!this._lastOn && s.co2ppm < onLow) this._lastOn = true;
     if ( this._lastOn && s.co2ppm > offHigh) this._lastOn = false;
 
-    if (this._lastOn && pulse > 0) addCO2Delta(s, pulse);
+    if (this._lastOn && pulse > 0) {
+      addCO2Delta(s, pulse);
+      const costEngine = zone?.costEngine ?? this.runtimeCtx?.zone?.costEngine;
+      costEngine?.bookCO2?.(pulse);
+    }
   }
 
   estimateEnergyKWh(_tickHours) {

--- a/src/engine/devices/HumidityControlUnit.js
+++ b/src/engine/devices/HumidityControlUnit.js
@@ -29,7 +29,11 @@ export class HumidityControlUnit extends BaseDevice {
       if (kg > 0) addLatentWater(s, -kg);
     } else if (this.state === 'humidifying') {
       const kg = Number(settings.humidifyRateKgPerTick ?? 0);
-      if (kg > 0) addLatentWater(s, kg);
+      if (kg > 0) {
+        addLatentWater(s, kg);
+        const costEngine = zone?.costEngine ?? this.runtimeCtx?.zone?.costEngine;
+        costEngine?.bookWater?.(kg);
+      }
     }
   }
 

--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -35,6 +35,7 @@ function addDeviceN(zone, blueprint, count, runtimeCtx, overrides = {}) {
       return [];
     }
     const n = Math.max(1, Math.floor(Number(count ?? 1)));
+    zone?.costEngine?.bookCapex?.(blueprint.id, n);
     const out = [];
     for (let i = 1; i <= n; i++) {
       const clone = JSON.parse(JSON.stringify(blueprint));


### PR DESCRIPTION
## Summary
- compute plant light stress only during scheduled lighting periods
- account for water usage, CO₂ injection, and device capex/seed costs
- extend cost engine to price CO₂ pulses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f0fb80c70832597d5cf203166e1c0