### PR TITLE
Photoperiod-aware stress and CO₂ accounting

### DIFF
--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -169,6 +169,10 @@ export class Zone {
     const currentSimHour = (tickIndex * this.tickLengthInHours) % 24;
 
     const lightsOn = currentSimHour < lightHours;
+    // expose lights-on state for plant stress calculations
+    if (this.runtime) {
+      this.runtime.lightsOn = lightsOn;
+    }
 
     for (const device of this.devices) {
       if (device.kind === 'Lamp') {
@@ -222,7 +226,6 @@ export class Zone {
           this.costEngine.bookRevenue('Harvest', revenue);
           this.logger.info({ plantId: plant.id.slice(0,8), yieldGrams: yieldGrams.toFixed(2), revenue: revenue.toFixed(2) }, 'HARVEST');
         }
-        this.costEngine.bookSeeds(strainId, 1);
 
         const newPlant = new Plant({
           strain: plant.strain,
@@ -231,6 +234,7 @@ export class Zone {
         });
         this.plants[i] = newPlant;
         this.logger.info({ oldPlantId: plant.id.slice(0,8), newPlantId: newPlant.id.slice(0,8) }, 'REPLANT');
+        this.costEngine.bookSeeds(strainId, 1);
       }
     }
   }

--- a/src/engine/devices/CO2Injector.js
+++ b/src/engine/devices/CO2Injector.js
@@ -21,7 +21,11 @@ export class CO2Injector extends BaseDevice {
     if (!this._lastOn && s.co2ppm < onLow) this._lastOn = true;
     if ( this._lastOn && s.co2ppm > offHigh) this._lastOn = false;
 
-    if (this._lastOn && pulse > 0) addCO2Delta(s, pulse);
+    if (this._lastOn && pulse > 0) {
+      addCO2Delta(s, pulse);
+      // book CO2 consumption via cost engine
+      this.runtimeCtx?.zone?.costEngine?.bookCO2(pulse, { zoneId: this.runtimeCtx?.zone?.id, deviceId: this.id });
+    }
   }
 
   estimateEnergyKWh(_tickHours) {

--- a/src/engine/devices/HumidityControlUnit.js
+++ b/src/engine/devices/HumidityControlUnit.js
@@ -29,7 +29,11 @@ export class HumidityControlUnit extends BaseDevice {
       if (kg > 0) addLatentWater(s, -kg);
     } else if (this.state === 'humidifying') {
       const kg = Number(settings.humidifyRateKgPerTick ?? 0);
-      if (kg > 0) addLatentWater(s, kg);
+      if (kg > 0) {
+        addLatentWater(s, kg);
+        // book water usage via cost engine if available
+        this.runtimeCtx?.zone?.costEngine?.bookWater(kg, { zoneId: this.runtimeCtx?.zone?.id, deviceId: this.id });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Only apply light stress when photoperiod calls for illumination
- Track humidifier water usage and CO₂ injector pulses through CostEngine
- Record seed costs after replanting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f11ef8ec88325a766d13901a3b855