### PR TITLE
Add tick aggregation history and company overview tabs

### DIFF
--- a/src/engine/CostEngine.js
+++ b/src/engine/CostEngine.js
@@ -60,6 +60,8 @@ export class CostEngine {
 
     this._tickCounter = 0;
     this._initEmptyLedger();
+    // Store snapshots of each tick's totals (for higher level aggregation)
+    this.tickHistory = [];
   }
 
   /** internal reset of the tick ledger */
@@ -292,6 +294,15 @@ export class CostEngine {
     this.grandTotalOtherExpenseEUR += this.ledger.otherExpenseEUR;
 
     return { ...totals, totalExpensesEUR: totals.totalExpensesEUR };
+  }
+
+  /**
+   * Store an external snapshot of tick totals for later aggregation.
+   * @param {object} totals
+   */
+  recordTickTotals(totals) {
+    if (!totals) return;
+    this.tickHistory.push({ ...totals });
   }
 
   /**


### PR DESCRIPTION
## Summary
- track per-tick totals and compute 24h/7d/1m aggregates on the server
- store tick summaries in the cost engine
- render company resource usage, cost breakdown, and financial position with period toggles on the frontend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f1a4d525483258314bd9a37f36ac6