### PR TITLE
Handle zone errors consistently on server and client

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -344,10 +344,11 @@ function renderStructureContent(root) {
             kpis.remove();
         }
         fetch(`/api/zones/${z.id}/overview`)
-            .then(res => res.json())
-            .then(dto => {
-                if (dto.error) {
-                    root.innerHTML += `<p style="color:var(--danger)">Error: ${dto.error}</p>`;
+            .then(res => res.json().then(dto => ({ ok: res.ok, dto })))
+            .then(({ ok, dto }) => {
+                if (!ok || dto.error || dto.message) {
+                    const msg = dto.error || dto.message || 'Unknown error';
+                    root.innerHTML += `<p style="color:var(--danger)">Error: ${msg}</p>`;
                     return;
                 }
                 renderZoneOverview(root, dto, z);
@@ -361,10 +362,11 @@ function renderStructureContent(root) {
         kpis.appendChild(card('Stress', (p.stress * 100).toFixed(1) + '%'));
         root.appendChild(kpis);
         fetch(`/api/zones/${z.id}/plants/${p.id}`)
-            .then(res => res.json())
-            .then(dto => {
-                if (dto.error) {
-                    root.innerHTML += `<p style="color:var(--danger)">Error: ${dto.error}</p>`;
+            .then(res => res.json().then(dto => ({ ok: res.ok, dto })))
+            .then(({ ok, dto }) => {
+                if (!ok || dto.error || dto.message) {
+                    const msg = dto.error || dto.message || 'Unknown error';
+                    root.innerHTML += `<p style="color:var(--danger)">Error: ${msg}</p>`;
                     return;
                 }
                 renderPlantDetail(root, dto, z);
@@ -412,10 +414,11 @@ function renderStructureContent(root) {
     }
     if (level === 'plants' && z) {
         fetch(`/api/zones/${z.id}/details`)
-            .then(res => res.json())
-            .then(dto => {
-                if (dto.error) {
-                    root.appendChild(section('Plants', `<p style="color:var(--danger)">Error: ${dto.error}</p>`));
+            .then(res => res.json().then(dto => ({ ok: res.ok, dto })))
+            .then(({ ok, dto }) => {
+                if (!ok || dto.error || dto.message) {
+                    const msg = dto.error || dto.message || 'Unknown error';
+                    root.appendChild(section('Plants', `<p style="color:var(--danger)">Error: ${msg}</p>`));
                     return;
                 }
                 renderZonePlantsDetails(root, dto);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -390,7 +390,7 @@ app.get('/api/zones/:zoneId/overview', (req, res) => {
   const { structure, costEngine } = simulationState;
 
   if (simulationState.status === 'stopped' || !structure) {
-    return res.status(404).send({ message: 'Simulation not running.' });
+    return res.status(404).send({ error: 'Simulation not running.' });
   }
 
   let zone = null;
@@ -403,7 +403,7 @@ app.get('/api/zones/:zoneId/overview', (req, res) => {
   }
 
   if (!zone) {
-    return res.status(404).send({ message: `Zone with id ${zoneId} not found.` });
+    return res.status(404).send({ error: `Zone with id ${zoneId} not found.` });
   }
 
   const dto = createZoneOverviewDTO(zone, costEngine);
@@ -415,7 +415,7 @@ app.get('/api/zones/:zoneId/details', (req, res) => {
   const { structure } = simulationState;
 
   if (simulationState.status === 'stopped' || !structure) {
-    return res.status(404).send({ message: 'Simulation not running.' });
+    return res.status(404).send({ error: 'Simulation not running.' });
   }
 
   // Find the zone in the hierarchy
@@ -429,7 +429,7 @@ app.get('/api/zones/:zoneId/details', (req, res) => {
   }
 
   if (!zone) {
-    return res.status(404).send({ message: `Zone with id ${zoneId} not found.` });
+    return res.status(404).send({ error: `Zone with id ${zoneId} not found.` });
   }
 
   const dto = createZoneDetailDTO(zone);
@@ -441,7 +441,7 @@ app.get('/api/zones/:zoneId/plants/:plantId', (req, res) => {
   const { structure } = simulationState;
 
   if (simulationState.status === 'stopped' || !structure) {
-    return res.status(404).send({ message: 'Simulation not running.' });
+    return res.status(404).send({ error: 'Simulation not running.' });
   }
 
   let zone = null;
@@ -453,12 +453,12 @@ app.get('/api/zones/:zoneId/plants/:plantId', (req, res) => {
     }
   }
   if (!zone) {
-    return res.status(404).send({ message: `Zone with id ${zoneId} not found.` });
+    return res.status(404).send({ error: `Zone with id ${zoneId} not found.` });
   }
 
   const plant = zone.plants.find(p => p.id === plantId);
   if (!plant) {
-    return res.status(404).send({ message: `Plant with id ${plantId} not found in zone ${zoneId}.` });
+    return res.status(404).send({ error: `Plant with id ${plantId} not found in zone ${zoneId}.` });
   }
 
   const dto = createPlantDetailDTO(zone, plant);


### PR DESCRIPTION
## Summary
- Return `error` objects from all zone-related server endpoints
- Check `res.ok` on zone fetches and surface `error`/`message` responses in UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f78fb46448325b3e3da6b9ee145ce