### PR TITLE
chore: set default tick length to one hour

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -4,7 +4,7 @@
 export const env = {
   time: {
     // Global default tick length in hours (can be overridden per simulation/zone)
-    tickLengthInHoursDefault: 3
+    tickLengthInHoursDefault: 1
   },
   physics: {
     // Air (at approx. 20–25°C)


### PR DESCRIPTION
## Summary
- shorten default tick length from three hours to one hour
- keep `TICK_HOURS_DEFAULT` exported from the updated default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fedf785748325895d7b6d3adc31ea