### PR TITLE
refactor: centralize tick duration resolution

### DIFF
--- a/src/demos/structure_rooms_zones_demo.js
+++ b/src/demos/structure_rooms_zones_demo.js
@@ -2,6 +2,7 @@
 import { logger } from '../lib/logger.js';
 import { createActor } from 'xstate';
 import { initializeSimulation } from '../sim/simulation.js';
+import { resolveTickHours } from '../lib/time.js';
 import { inspect } from 'util'; // For deep logging
 
 // A helper to log deep objects
@@ -15,7 +16,7 @@ async function main() {
   const { structure, costEngine, tickMachineLogic } = await initializeSimulation();
 
   const durationTicks = 10;
-  const tickLengthInHours = structure.rooms[0]?.zones[0]?.tickLengthInHours ?? 3;
+  const tickLengthInHours = resolveTickHours(structure.rooms[0]?.zones[0]);
   const ticksPerDay = Math.round(24 / tickLengthInHours);
 
   logger.info(`--- STARTING HIERARCHICAL SIMULATION (1 tick = ${tickLengthInHours}h, 1 day = ${ticksPerDay} ticks) ---`);

--- a/src/engine/BaseDevice.js
+++ b/src/engine/BaseDevice.js
@@ -2,6 +2,7 @@
 // Prices/maintenance are separate (devicePrices.json).
 import _ from 'lodash';
 import { env } from '../config/env.js';
+import { resolveTickHours } from '../lib/time.js';
 
 const { pick } = _;
 
@@ -47,7 +48,7 @@ export class BaseDevice {
     this.ageTicks = 0;
 
     this.zoneRef = runtime?.zone ?? null;
-    this.tickLengthInHours = runtime?.tickLengthInHours ?? (env.time.tickLengthInHoursDefault ?? 3);
+    this.tickLengthInHours = resolveTickHours(runtime);
   }
 
   /**

--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -4,6 +4,7 @@
 
 import { ensureEnv, addLatentWater, addCO2Delta } from './deviceUtils.js';
 import { env } from '../config/env.js';
+import { resolveTickHours } from '../lib/time.js';
 import { v4 as uuidv4 } from 'uuid';
 import { createRng } from '../lib/rng.js';
 
@@ -56,6 +57,7 @@ export class Plant {
     const L = Number(s.ppfd ?? 0);           // µmol/m²·s
     const T = Number(s.temperature ?? 24);   // °C
     const RH = Number(s.humidity ?? 0.6);    // 0..1
+    const tickH = resolveTickHours({ tickLengthInHours: zone?.tickLengthInHours ?? tickLengthInHours });
 
     const difficulty = zone.runtime?.difficulty?.plantStress ?? {};
     const optimalRangeMultiplier = difficulty.optimalRangeMultiplier ?? 1.0;
@@ -68,7 +70,6 @@ export class Plant {
       if (lightCycle) {
         const cycle = lightCycle[this.stage] ?? lightCycle.default ?? [18, 6];
         const lightHours = cycle[0];
-        const tickH = Number(zone.tickLengthInHours ?? tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
         const currentSimHour = (tickIndex * tickH) % 24;
         lightsOn = currentSimHour < lightHours;
       } else {
@@ -156,7 +157,7 @@ export class Plant {
 
 
     // ---- Age & simple stage logic (optional/placeholder) ----
-    this.ageHours += Number(tickLengthInHours || env.time.tickLengthInHoursDefault || 3);
+    this.ageHours += tickH;
 
     const vegDays = this.strain?.photoperiod?.vegetationDays ?? 21;
     const flowerDays = this.strain?.photoperiod?.floweringDays ?? 56;

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -1,6 +1,7 @@
 // src/engine/Zone.js
 import { ensureEnv, resetEnvAggregates, getZoneVolume, clamp } from './deviceUtils.js';
-import { env, AIR_DENSITY, AIR_CP, TICK_HOURS_DEFAULT } from '../config/env.js';
+import { env, AIR_DENSITY, AIR_CP } from '../config/env.js';
+import { resolveTickHours } from '../lib/time.js';
 import { Plant } from './Plant.js';
 import { createDevice } from './factories/deviceFactory.js';
 
@@ -17,7 +18,7 @@ export class Zone {
     name = 'Zone',
     area = 1,
     height, // Inherited from Room/Structure
-    tickLengthInHours = (env?.time?.tickLengthInHoursDefault ?? 3),
+    tickLengthInHours,
     runtime = {},
     roomId = null,
     structureId = null,
@@ -26,7 +27,7 @@ export class Zone {
     this.name = name;
     this.area = Number(area);
     this.height = height; // Let validation/inheritance handle Number() conversion and defaults
-    this.tickLengthInHours = Number(tickLengthInHours);
+    this.tickLengthInHours = resolveTickHours({ tickLengthInHours });
     this.roomId = roomId;
     this.structureId = structureId;
 
@@ -276,7 +277,7 @@ export class Zone {
 
   #applyThermalUpdate() {
     const s = ensureEnv(this);
-    const tickH  = Number(this.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const tickH  = resolveTickHours(this);
     const dtSec  = Math.max(1, tickH * (env?.factors?.hourToSec ?? 3600));
 
     const rhoAir = Number(env?.physics?.airDensity ?? AIR_DENSITY ?? 1.2);

--- a/src/engine/deviceUtils.js
+++ b/src/engine/deviceUtils.js
@@ -2,6 +2,7 @@
 // Helper functions for device and environment logic (ESM, Node 23+)
 
 import { env } from '../config/env.js';
+import { resolveTickHours } from '../lib/time.js';
 
 export function toNumber(v, def = 0) {
   const n = Number(v);
@@ -78,7 +79,7 @@ export function getZoneVolume(zone) {
 }
 
 export function getTickHours(runtimeCtx) {
-  return toNumber(runtimeCtx?.tickLengthInHours, env?.time?.tickLengthInHoursDefault ?? 3);
+  return resolveTickHours(runtimeCtx);
 }
 
 export function readPowerKw(settings = {}) {

--- a/src/engine/devices/ClimateUnit.js
+++ b/src/engine/devices/ClimateUnit.js
@@ -3,6 +3,7 @@
 import { env, AIR_DENSITY, AIR_CP } from '../../config/env.js';
 import { BaseDevice } from '../BaseDevice.js';
 import { ensureEnv, getZoneVolume, clamp } from '../deviceUtils.js';
+import { resolveTickHours } from '../../lib/time.js';
 
 export class ClimateUnit extends BaseDevice {
   constructor(json, runtimeCtx) {
@@ -14,7 +15,7 @@ export class ClimateUnit extends BaseDevice {
   applyEffect(zone) {
     const s = ensureEnv(zone);
     const settings = this.settings ?? {};
-    const tickH   = Number(this.runtimeCtx?.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const tickH   = resolveTickHours(this.runtimeCtx);
     const dtSec   = Math.max(1, tickH * (env?.factors?.hourToSec ?? 3600));
 
     // Setpoint & Hysterese
@@ -71,7 +72,7 @@ export class ClimateUnit extends BaseDevice {
   }
 
   estimateEnergyKWh(tickHours) {
-    const tickH = Number(tickHours ?? this.runtimeCtx?.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const tickH = resolveTickHours({ tickLengthInHours: tickHours ?? this.runtimeCtx?.tickLengthInHours });
     const powerElKW = Number(this.settings?.power ?? this.settings?.powerInKilowatts ?? 0);
     return Math.max(0, powerElKW * clamp(this._lastPowerFrac ?? 0, 0, 1) * tickH);
   }

--- a/src/engine/devices/Dehumidifier.js
+++ b/src/engine/devices/Dehumidifier.js
@@ -3,6 +3,7 @@
 import { BaseDevice } from '../BaseDevice.js';
 import { ensureEnv, addLatentWater } from '../deviceUtils.js';
 import { env } from '../../config/env.js';
+import { resolveTickHours } from '../../lib/time.js';
 
 export class Dehumidifier extends BaseDevice {
   constructor(json, runtimeCtx) {
@@ -17,7 +18,7 @@ export class Dehumidifier extends BaseDevice {
   }
 
   estimateEnergyKWh(tickHours) {
-    const h = Number(tickHours ?? this.runtimeCtx?.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const h = resolveTickHours({ tickLengthInHours: tickHours ?? this.runtimeCtx?.tickLengthInHours });
     const p = Number(this.settings?.power ?? 0); // kW(el)
     return Math.max(0, p * h);
   }

--- a/src/engine/devices/HumidityControlUnit.js
+++ b/src/engine/devices/HumidityControlUnit.js
@@ -2,6 +2,7 @@
 import { BaseDevice } from '../BaseDevice.js';
 import { ensureEnv, addLatentWater } from '../deviceUtils.js';
 import { env } from '../../config/env.js';
+import { resolveTickHours } from '../../lib/time.js';
 
 export class HumidityControlUnit extends BaseDevice {
   constructor(json, runtimeCtx) {
@@ -41,7 +42,7 @@ export class HumidityControlUnit extends BaseDevice {
     if (this.state === 'idle') {
       return 0;
     }
-    const h = Number(tickHours ?? this.runtimeCtx?.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const h = resolveTickHours({ tickLengthInHours: tickHours ?? this.runtimeCtx?.tickLengthInHours });
     const p = Number(this.settings?.power ?? 0); // kW(el)
     return Math.max(0, p * h);
   }

--- a/src/engine/devices/Lamp.js
+++ b/src/engine/devices/Lamp.js
@@ -2,6 +2,7 @@
 import { BaseDevice } from '../BaseDevice.js';
 import { ensureEnv, readPowerKw, readPPFD } from '../deviceUtils.js';
 import { env } from '../../config/env.js';
+import { resolveTickHours } from '../../lib/time.js';
 
 export class Lamp extends BaseDevice {
   constructor(json, runtimeCtx) {
@@ -55,7 +56,7 @@ export class Lamp extends BaseDevice {
     if (this.state === 'off') {
       return 0;
     }
-    const h = Number(tickHours ?? this.runtimeCtx?.tickLengthInHours ?? env?.time?.tickLengthInHoursDefault ?? 3);
+    const h = resolveTickHours({ tickLengthInHours: tickHours ?? this.runtimeCtx?.tickLengthInHours });
     const powerKW = readPowerKw(this.settings ?? {});
     return Math.max(0, powerKW * h);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 // src/index.js
-import { TICK_HOURS_DEFAULT } from './config/env.js';
 import { logger } from './lib/logger.js';
 import { emit } from './sim/eventBus.js';
 import { createActor } from 'xstate';
 import { initializeSimulation } from './sim/simulation.js';
+import { resolveTickHours } from './lib/time.js';
 
 // --- Main -------------------------------------------------------------------
 async function main() {
@@ -11,9 +11,10 @@ async function main() {
 
   // Simulation run for this zone
   const durationTicks = 840; // 105 days, static for now
-  const ticksPerDay = Math.round(24 / (zones[0]?.tickLengthInHours ?? TICK_HOURS_DEFAULT));
+  const tickLengthInHours = resolveTickHours(zones[0]);
+  const ticksPerDay = Math.round(24 / tickLengthInHours);
 
-  logger.info(`--- STARTING SIMULATION (1 tick = ${zones[0]?.tickLengthInHours}h, 1 day = ${ticksPerDay} ticks) ---`);
+  logger.info(`--- STARTING SIMULATION (1 tick = ${tickLengthInHours}h, 1 day = ${ticksPerDay} ticks) ---`);
 
   for (let i = 1; i <= durationTicks; i++) {
     const absoluteTick = (costEngine._tickCounter || 0) + 1;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { logger } from '../lib/logger.js';
+import { resolveTickHours } from '../lib/time.js';
 import { createActor } from 'xstate';
 import fs from 'fs';
 import { uiStream$ } from '../sim/eventBus.js';
@@ -367,7 +368,7 @@ app.get('/simulation/status', (req, res) => {
     return res.status(404).send({ message: 'Simulation not started.' });
   }
 
-  const tickLengthInHours = structure.rooms[0]?.zones[0]?.tickLengthInHours ?? 3;
+  const tickLengthInHours = resolveTickHours(structure.rooms[0]?.zones[0]);
 
   res.status(200).send({
     status,

--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -1,4 +1,3 @@
-import { TICK_HOURS_DEFAULT } from '../config/env.js';
 import { Zone } from '../engine/Zone.js';
 import { Plant } from '../engine/Plant.js';
 import { logger } from '../lib/logger.js';

--- a/src/sim/tickMachine.js
+++ b/src/sim/tickMachine.js
@@ -3,6 +3,7 @@
 
 import { createMachine, assign, setup, fromPromise } from 'xstate';
 import { emit } from './eventBus.js';
+import { resolveTickHours } from '../lib/time.js';
 
 /**
  * Creates the tick state machine logic.
@@ -82,7 +83,7 @@ export function createTickMachine() {
       context: ({ input }) => ({
         zone: input.zone ?? null,
         tick: input.tick ?? 0,
-        tickLengthInHours: input.tickLengthInHours ?? 3,
+        tickLengthInHours: resolveTickHours(input.zone || { tickLengthInHours: input.tickLengthInHours }),
         logger: input.logger ?? console,
       }),
       states: {


### PR DESCRIPTION
## Summary
- use `resolveTickHours` across engine, devices, server and demos
- replace hard-coded tick defaults with context-aware resolution
- streamline tick machine and zone constructor to derive duration via helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fef02d2ec8325b9b5568db35b9650