### PR TITLE
Add device tests and fix runtime context handling

### DIFF
--- a/src/engine/BaseDevice.js
+++ b/src/engine/BaseDevice.js
@@ -49,6 +49,7 @@ export class BaseDevice {
 
     this.zoneRef = runtime?.zone ?? null;
     this.tickLengthInHours = resolveTickHours(runtime);
+    this.runtimeCtx = runtime;
   }
 
   /**

--- a/tests/climateUnit.test.js
+++ b/tests/climateUnit.test.js
@@ -1,0 +1,46 @@
+import { ClimateUnit } from '../src/engine/devices/ClimateUnit.js';
+import { ensureEnv } from '../src/engine/deviceUtils.js';
+
+describe('ClimateUnit', () => {
+  function makeZone(temp) {
+    const zone = { };
+    const env = ensureEnv(zone);
+    env.temperature = temp;
+    return zone;
+  }
+
+  it('stays off within hysteresis band', () => {
+    const zone = makeZone(24);
+    const unit = new ClimateUnit({ id: 'cl1', kind: 'ClimateUnit', settings: { targetTemperature: 24, hysteresisK: 1, power: 1 } }, { tickLengthInHours: 1 });
+    unit.applyEffect(zone);
+    expect(unit._on).toBe(false);
+    expect(zone.environment._heatW).toBe(0);
+  });
+
+  it('turns on above upper threshold and cools', () => {
+    const zone = makeZone(25);
+    const unit = new ClimateUnit({ id: 'cl1', kind: 'ClimateUnit', settings: { targetTemperature: 24, hysteresisK: 1, power: 1 } }, { tickLengthInHours: 1 });
+    unit.applyEffect(zone);
+    expect(unit._on).toBe(true);
+    expect(zone.environment._heatW).toBeLessThan(0);
+  });
+
+  it('turns off when cooled below lower threshold', () => {
+    const zone = makeZone(25);
+    const unit = new ClimateUnit({ id: 'cl1', kind: 'ClimateUnit', settings: { targetTemperature: 24, hysteresisK: 1, power: 1 } }, { tickLengthInHours: 1 });
+    unit.applyEffect(zone); // turn on
+    zone.environment.temperature = 23; // below target - hyst/2 (23.5)
+    zone.environment._heatW = 0;
+    unit.applyEffect(zone);
+    expect(unit._on).toBe(false);
+    expect(zone.environment._heatW).toBe(0);
+  });
+
+  it('estimates energy based on power and duty cycle', () => {
+    const zone = makeZone(25);
+    const unit = new ClimateUnit({ id: 'cl1', kind: 'ClimateUnit', settings: { targetTemperature: 24, hysteresisK: 1, power: 2 } }, { tickLengthInHours: 1 });
+    unit.applyEffect(zone);
+    const expected = unit.settings.power * unit._lastPowerFrac * 1; // tick = 1h
+    expect(unit.estimateEnergyKWh()).toBeCloseTo(expected, 5);
+  });
+});

--- a/tests/co2Injector.test.js
+++ b/tests/co2Injector.test.js
@@ -1,28 +1,49 @@
 import { CO2Injector } from '../src/engine/devices/CO2Injector.js';
 import { ensureEnv } from '../src/engine/deviceUtils.js';
+import { jest } from '@jest/globals';
 
 describe('CO2Injector', () => {
-  function makeZone(ppm) {
-    const zone = {};
+  function setup(ppm, extraSettings = {}) {
+    const costEngine = { bookCO2: jest.fn() };
+    const zone = { id: 'z1', costEngine };
     const env = ensureEnv(zone);
     env.co2ppm = ppm;
-    return zone;
+    const settings = { targetCO2: 800, hysteresis: 100, pulsePpmPerTick: 50, ...extraSettings };
+    const injector = new CO2Injector({ id: 'c1', kind: 'CO2Injector', settings }, { zone });
+    return { zone, env, injector, costEngine };
   }
 
   it('remains off within target range', () => {
-    const zone = makeZone(800);
-    const injector = new CO2Injector({ id: 'c1', kind: 'CO2Injector', settings: { targetCO2: 800, hysteresis: 100, pulsePpmPerTick: 50 } }, { zone });
+    const { zone, injector } = setup(800);
     injector.applyEffect(zone);
     expect(zone.environment._co2PpmDelta).toBe(0);
     expect(injector._lastOn).toBe(false);
   });
 
-  it('activates when below lower threshold', () => {
-    const zone = makeZone(700);
-    const injector = new CO2Injector({ id: 'c1', kind: 'CO2Injector', settings: { targetCO2: 800, hysteresis: 100, pulsePpmPerTick: 50 } }, { zone });
+  it('activates when below lower threshold and books CO2', () => {
+    const { zone, injector, costEngine } = setup(700);
     injector.applyEffect(zone);
     expect(zone.environment._co2PpmDelta).toBeGreaterThan(0);
     expect(injector._lastOn).toBe(true);
+    expect(costEngine.bookCO2).toHaveBeenCalledWith(50, { zoneId: zone.id, deviceId: injector.id });
+  });
+
+  it('mode off disables injection', () => {
+    const { zone, injector } = setup(700, { mode: 'off' });
+    injector.applyEffect(zone);
+    expect(zone.environment._co2PpmDelta).toBe(0);
+    expect(injector._lastOn).toBe(false);
+  });
+
+  it('stays off at hysteresis boundaries', () => {
+    const { zone: zoneLow, injector: injLow } = setup(750);
+    injLow.applyEffect(zoneLow);
+    expect(zoneLow.environment._co2PpmDelta).toBe(0);
+    expect(injLow._lastOn).toBe(false);
+
+    const { zone: zoneHigh, injector: injHigh } = setup(850);
+    injHigh.applyEffect(zoneHigh);
+    expect(zoneHigh.environment._co2PpmDelta).toBe(0);
+    expect(injHigh._lastOn).toBe(false);
   });
 });
-

--- a/tests/dehumidifier.test.js
+++ b/tests/dehumidifier.test.js
@@ -1,0 +1,18 @@
+import { Dehumidifier } from '../src/engine/devices/Dehumidifier.js';
+import { ensureEnv } from '../src/engine/deviceUtils.js';
+
+describe('Dehumidifier', () => {
+  it('removes moisture according to rate', () => {
+    const zone = {};
+    const env = ensureEnv(zone);
+    const device = new Dehumidifier({ id: 'd1', kind: 'Dehumidifier', settings: { latentRemovalKgPerTick: 0.2 } }, { tickLengthInHours: 1 });
+    device.applyEffect(zone);
+    expect(env._waterKgDelta).toBeCloseTo(-0.2);
+  });
+
+  it('estimates energy based on tick length', () => {
+    const device = new Dehumidifier({ id: 'd1', kind: 'Dehumidifier', settings: { power: 2 } }, { tickLengthInHours: 1 });
+    expect(device.estimateEnergyKWh(0.5)).toBeCloseTo(1); // 2 kW * 0.5 h
+    expect(device.estimateEnergyKWh(2)).toBeCloseTo(4);    // 2 kW * 2 h
+  });
+});

--- a/tests/humidityControlUnit.test.js
+++ b/tests/humidityControlUnit.test.js
@@ -1,0 +1,40 @@
+import { HumidityControlUnit } from '../src/engine/devices/HumidityControlUnit.js';
+import { ensureEnv } from '../src/engine/deviceUtils.js';
+import { jest } from '@jest/globals';
+
+describe('HumidityControlUnit', () => {
+  function setup(humidity) {
+    const costEngine = { bookWater: jest.fn() };
+    const zone = { id: 'z1', costEngine };
+    const env = ensureEnv(zone);
+    env.humidity = humidity;
+    const runtimeCtx = { zone, tickLengthInHours: 1 };
+    return { zone, env, runtimeCtx, costEngine };
+  }
+
+  it('dehumidifies when above threshold', () => {
+    const { zone, env, runtimeCtx } = setup(0.8);
+    const unit = new HumidityControlUnit({ id: 'h1', kind: 'HumidityControlUnit', settings: { targetHumidity: 0.6, hysteresis: 0.1, dehumidifyRateKgPerTick: 0.05 } }, runtimeCtx);
+    unit.applyEffect(zone);
+    expect(unit.state).toBe('dehumidifying');
+    expect(env._waterKgDelta).toBeCloseTo(-0.05);
+  });
+
+  it('humidifies and books water when below threshold', () => {
+    const { zone, env, runtimeCtx, costEngine } = setup(0.4);
+    const unit = new HumidityControlUnit({ id: 'h1', kind: 'HumidityControlUnit', settings: { targetHumidity: 0.6, hysteresis: 0.1, humidifyRateKgPerTick: 0.03 } }, runtimeCtx);
+    unit.applyEffect(zone);
+    expect(unit.state).toBe('humidifying');
+    expect(env._waterKgDelta).toBeCloseTo(0.03);
+    expect(costEngine.bookWater).toHaveBeenCalledWith(0.03, { zoneId: zone.id, deviceId: unit.id });
+  });
+
+  it('stays idle within hysteresis band', () => {
+    const { zone, env, runtimeCtx, costEngine } = setup(0.6);
+    const unit = new HumidityControlUnit({ id: 'h1', kind: 'HumidityControlUnit', settings: { targetHumidity: 0.6, hysteresis: 0.1, humidifyRateKgPerTick: 0.03, dehumidifyRateKgPerTick: 0.05 } }, runtimeCtx);
+    unit.applyEffect(zone);
+    expect(unit.state).toBe('idle');
+    expect(env._waterKgDelta).toBe(0);
+    expect(costEngine.bookWater).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lamp.test.js
+++ b/tests/lamp.test.js
@@ -1,0 +1,28 @@
+import { Lamp } from '../src/engine/devices/Lamp.js';
+import { ensureEnv } from '../src/engine/deviceUtils.js';
+
+describe('Lamp', () => {
+  function setup(state = 'on') {
+    const zone = { area: 1 };
+    const env = ensureEnv(zone);
+    const lamp = new Lamp({ id: 'l1', kind: 'Lamp', settings: { power: 1, heatFraction: 0.5, ppfd: 200, coverageArea: 1 } }, { tickLengthInHours: 1 });
+    if (state === 'off') lamp.toggle('off');
+    return { zone, env, lamp };
+  }
+
+  it('does nothing when toggled off', () => {
+    const { zone, env, lamp } = setup('off');
+    lamp.applyEffect(zone);
+    expect(env._heatW).toBe(0);
+    expect(env.ppfd).toBe(0);
+    expect(lamp.estimateEnergyKWh()).toBe(0);
+  });
+
+  it('adds heat and ppfd when on', () => {
+    const { zone, env, lamp } = setup('on');
+    lamp.applyEffect(zone);
+    expect(env._heatW).toBeCloseTo(500); // 1 kW * 1000 * 0.5
+    expect(env.ppfd).toBeCloseTo(200);
+    expect(lamp.estimateEnergyKWh(2)).toBeCloseTo(2); // 1 kW * 2 h
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ClimateUnit, Dehumidifier, HumidityControlUnit, Lamp and extend CO2Injector tests
- ensure BaseDevice stores runtime context so devices can book costs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff4ea28208325ad991e2842532ee7