### PR TITLE
Use IDs for savegame devices and strains

### DIFF
--- a/data/savegames/default.json
+++ b/data/savegames/default.json
@@ -26,14 +26,14 @@
             "area": 20,
             "height": 2.8,
             "simulation": {
-              "strainSlug": "ak-47",
+              "strainId": "550e8400-e29b-41d4-a716-446655440000",
               "methodId": "sog"
             },
             "devices": [
-              { "kind": "Lamp", "count": 16 },
-              { "kind": "ClimateUnit", "count": 1, "overrides": { "targetTemperature": 24 } },
-              { "kind": "HumidityControlUnit", "count": 1, "overrides": { "targetHumidity": 0.6 } },
-              { "kind": "CO2Injector", "count": 1 }
+              { "blueprintId": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e", "count": 16 },
+              { "blueprintId": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b", "count": 1, "overrides": { "targetTemperature": 24 } },
+              { "blueprintId": "3d762260-88a5-4104-b03c-9860bbac34b6", "count": 1, "overrides": { "targetHumidity": 0.6 } },
+              { "blueprintId": "c701efa6-1e90-4f28-8934-ea9c584596e4", "count": 1 }
             ]
           },
           {
@@ -41,14 +41,14 @@
             "name": "Zone A2 (White Widow)",
             "area": 30,
             "simulation": {
-              "strainSlug": "white-widow",
+              "strainId": "550e8400-e29b-41d4-a716-446655440001",
               "methodId": "scrog"
             },
             "devices": [
-              { "kind": "Lamp", "count": 25 },
-              { "kind": "ClimateUnit", "count": 1, "overrides": { "targetTemperature": 22 } },
-              { "kind": "HumidityControlUnit", "count": 2, "overrides": { "targetHumidity": 0.6 } },
-              { "kind": "CO2Injector", "count": 1 }
+              { "blueprintId": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e", "count": 25 },
+              { "blueprintId": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b", "count": 1, "overrides": { "targetTemperature": 22 } },
+              { "blueprintId": "3d762260-88a5-4104-b03c-9860bbac34b6", "count": 2, "overrides": { "targetHumidity": 0.6 } },
+              { "blueprintId": "c701efa6-1e90-4f28-8934-ea9c584596e4", "count": 1 }
             ]
           }
         ]
@@ -64,9 +64,9 @@
             "name": "Breeding Zone",
             "area": 35,
             "devices": [
-              { "kind": "Lamp", "count": 2, "overrides": { "power": 0.250 } },
-              { "kind": "ClimateUnit", "count": 1, "overrides": { "targetTemperature": 21 } },
-              { "kind": "HumidityControlUnit", "count": 1, "overrides": { "targetHumidity": 0.55 } }
+              { "blueprintId": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e", "count": 2, "overrides": { "power": 0.250 } },
+              { "blueprintId": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b", "count": 1, "overrides": { "targetTemperature": 21 } },
+              { "blueprintId": "3d762260-88a5-4104-b03c-9860bbac34b6", "count": 1, "overrides": { "targetHumidity": 0.55 } }
             ]
           }
         ]

--- a/docs/schema/zone_schema.md
+++ b/docs/schema/zone_schema.md
@@ -13,7 +13,7 @@ These are the fields defined in the JSON configuration.
 | `area`     | `number` | The floor area of the zone in square meters (m²).                                                       | Yes      |                    |
 | `height`   | `number` | The ceiling height in meters (m). If not provided, it is inherited from the parent `Room`.                | No       | Inherited          |
 | `devices`  | `Array`  | An array of device configurations to be created within this zone.                                       | No       | `[]` (empty array) |
-| `simulation`| `object`| Configuration for the plants to be grown in this zone, including `strainSlug` and `methodId`.          | No       |                    |
+| `simulation`| `object`| Configuration for the plants to be grown in this zone, including `strainId` and `methodId`.          | No       |                    |
 
 ## Runtime-Injected Fields
 
@@ -33,12 +33,12 @@ These fields are added to the `Zone` instance at runtime by the simulation engin
   "area": 20,
   "height": 2.8,
   "simulation": {
-    "strainSlug": "ak-47",
+    "strainId": "550e8400-e29b-41d4-a716-446655440000",
     "methodId": "sog"
   },
   "devices": [
-    { "kind": "Lamp", "count": 8 },
-    { "kind": "ClimateUnit", "count": 2 }
+    { "blueprintId": "3b5f6ad7-672e-47cd-9a24-f0cc45c4101e", "count": 8 },
+    { "blueprintId": "7d3d3f1a-8c6f-4e9c-926d-5a2a4a3b6f1b", "count": 2 }
   ]
 }
 ```

--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -3,7 +3,7 @@ import { Plant } from '../engine/Plant.js';
 import { logger } from '../lib/logger.js';
 import { createDevice } from '../engine/factories/deviceFactory.js';
 import * as DeviceLoader from '../engine/loaders/deviceLoader.js';
-import { loadStrainBySlug } from '../engine/loaders/strainLoader.js';
+import { loadStrainById } from '../engine/loaders/strainLoader.js';
 import { loadCultivationMethod } from '../engine/loaders/cultivationMethodLoader.js';
 import { loadDevicePriceMap, loadStrainPriceMap } from '../engine/loaders/priceLoader.js';
 import { CostEngine } from '../engine/CostEngine.js';
@@ -101,7 +101,7 @@ export async function initializeSimulation(savegame = 'default', difficulty = 'n
             const deviceRuntimeCtx = { zone, tickLengthInHours: zone.tickLengthInHours, devicePriceMap, logger: zone.logger, rng };
             if (zoneConfig.devices) {
                 for (const device of zoneConfig.devices) {
-                    const blueprint = findBlueprint(blueprints, { kind: device.kind });
+                    const blueprint = findBlueprint(blueprints, { id: device.blueprintId });
                     addDeviceN(zone, blueprint, device.count, deviceRuntimeCtx, device.overrides);
                 }
             }
@@ -110,7 +110,7 @@ export async function initializeSimulation(savegame = 'default', difficulty = 'n
             const { simulation: simConfig } = zoneConfig;
             if (simConfig) {
                 const method = await loadCultivationMethod(simConfig.methodId);
-                const strain = await loadStrainBySlug(simConfig.strainSlug);
+                const strain = await loadStrainById(simConfig.strainId);
                 const numPlants = Math.floor(zone.area / method.areaPerPlant);
                 for (let i = 0; i < numPlants; i++) {
                     const area_m2 = method?.areaPerPlant ?? 0.25;


### PR DESCRIPTION
## Summary
- replace device `kind` references in savegames with `blueprintId`
- load strains by `strainId` and devices by `blueprintId`
- document new `strainId` and `blueprintId` fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0033c17008325b9b017987d79d6d3