### PR TITLE
feat: add strain editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ out/
 # Projekt-spezifisch: Keine generierten JSON-Instanzen im Repo
 data/generated/
 data/cache/
+data/strain/backup/

--- a/frontend/editor/strainEditor.js
+++ b/frontend/editor/strainEditor.js
@@ -1,0 +1,139 @@
+export default async function renderStrainEditor(root) {
+  root.innerHTML = `
+    <div class="section">
+      <header style="display:flex;justify-content:space-between;align-items:center">
+        <strong>Strain Editor</strong>
+        <button id="new-strain" class="btn">Neu</button>
+      </header>
+      <form id="strain-form" style="display:flex;flex-direction:column;gap:8px;margin-top:12px;">
+        <label>ID <input id="strain-id" readonly></label>
+        <label>Name* <input id="strain-name" required></label>
+        <label>Parents
+          <select id="strain-parents" multiple size="5"></select>
+        </label>
+        <label>Genotype*
+          <div style="display:flex;gap:4px;">
+            <input id="gen-sativa" type="number" step="0.01" placeholder="Sativa">
+            <input id="gen-indica" type="number" step="0.01" placeholder="Indica">
+            <input id="gen-ruderalis" type="number" step="0.01" placeholder="Ruderalis">
+          </div>
+        </label>
+        <label>Resilience* <input id="strain-resilience" type="number" step="0.01"></label>
+        <div id="message" style="color:var(--danger)"></div>
+        <div><button type="submit" class="btn primary">Speichern</button></div>
+      </form>
+    </div>
+    <div class="section">
+      <header>Existing Strains</header>
+      <ul id="strain-list" style="list-style:none;padding:0;display:flex;flex-direction:column;gap:4px;"></ul>
+    </div>
+  `;
+
+  let currentId = null;
+
+  async function loadList() {
+    const res = await fetch('/api/strains');
+    const data = await res.json();
+    const list = document.getElementById('strain-list');
+    const parents = document.getElementById('strain-parents');
+    list.innerHTML = '';
+    parents.innerHTML = '';
+    data.forEach(s => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.textContent = s.name;
+      btn.className = 'btn';
+      btn.addEventListener('click', () => loadStrain(s.id));
+      li.appendChild(btn);
+      list.appendChild(li);
+      const opt = document.createElement('option');
+      opt.value = s.id;
+      opt.textContent = s.name;
+      parents.appendChild(opt);
+    });
+  }
+
+  function newStrain() {
+    currentId = crypto.randomUUID();
+    document.getElementById('strain-id').value = currentId;
+    document.getElementById('strain-name').value = '';
+    document.getElementById('strain-resilience').value = '';
+    document.getElementById('gen-sativa').value = '';
+    document.getElementById('gen-indica').value = '';
+    document.getElementById('gen-ruderalis').value = '';
+    Array.from(document.getElementById('strain-parents').options).forEach(o => o.selected = false);
+  }
+
+  async function loadStrain(id) {
+    const res = await fetch(`/api/strains/${id}`);
+    if (!res.ok) return;
+    const s = await res.json();
+    currentId = s.id;
+    document.getElementById('strain-id').value = s.id || '';
+    document.getElementById('strain-name').value = s.name || '';
+    document.getElementById('strain-resilience').value = s.generalResilience ?? '';
+    document.getElementById('gen-sativa').value = s.genotype?.sativa ?? '';
+    document.getElementById('gen-indica').value = s.genotype?.indica ?? '';
+    document.getElementById('gen-ruderalis').value = s.genotype?.ruderalis ?? '';
+    const parentsSelect = document.getElementById('strain-parents');
+    Array.from(parentsSelect.options).forEach(opt => {
+      opt.selected = s.lineage?.parents?.includes(opt.value);
+    });
+  }
+
+  document.getElementById('new-strain').addEventListener('click', () => {
+    newStrain();
+  });
+
+  document.getElementById('strain-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const msg = document.getElementById('message');
+    msg.style.color = 'var(--danger)';
+    msg.textContent = '';
+    const name = document.getElementById('strain-name').value.trim();
+    const resilience = document.getElementById('strain-resilience').value;
+    if (!name || resilience === '') {
+      msg.textContent = 'Name und Resilience sind Pflichtfelder';
+      return;
+    }
+    const strain = {
+      id: currentId,
+      name,
+      generalResilience: Number(resilience),
+      genotype: {
+        sativa: Number(document.getElementById('gen-sativa').value) || 0,
+        indica: Number(document.getElementById('gen-indica').value) || 0,
+        ruderalis: Number(document.getElementById('gen-ruderalis').value) || 0,
+      },
+      lineage: {
+        parents: Array.from(document.getElementById('strain-parents').selectedOptions).map(o => o.value),
+      },
+    };
+    let url = '/api/strains';
+    let method = 'POST';
+    if (currentId && (await exists(`/api/strains/${currentId}`))) {
+      url += `/${currentId}`;
+      method = 'PUT';
+    }
+    const resp = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(strain) });
+    if (resp.ok) {
+      const saved = await resp.json();
+      currentId = saved.id;
+      document.getElementById('strain-id').value = saved.id;
+      msg.style.color = 'var(--ok)';
+      msg.textContent = 'Gespeichert';
+      await loadList();
+    } else {
+      const err = await resp.json();
+      msg.textContent = err.error || err.message || 'Fehler';
+    }
+  });
+
+  async function exists(url) {
+    const res = await fetch(url, { method: 'GET' });
+    return res.ok;
+  }
+
+  await loadList();
+  newStrain();
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,6 +93,7 @@
         <button class="rbtn" id="rb-structure" data-mode="structure" aria-pressed="true">🏗️ Structure</button>
         <button class="rbtn" id="rb-company" data-mode="company" aria-pressed="false">🏢 Company</button>
         <button class="rbtn" id="rb-shop" data-mode="shop" aria-pressed="false">🛒 Shop</button>
+        <button class="rbtn" id="rb-editor" data-mode="editor" aria-pressed="false">✏️ Editor</button>
       </div>
       <ul class="tree" id="tree" role="tree" aria-label="Explorer"><!-- built by JS --></ul>
     </aside>

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,6 +10,7 @@ import { createActor } from 'xstate';
 import fs from 'fs';
 import { uiStream$ } from '../sim/eventBus.js';
 import { initializeSimulation } from '../sim/simulation.js';
+import strainEditorService from './services/strainEditorService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +28,8 @@ app.use(express.static(path.join(__dirname, '..', '..', 'frontend')));
 // Serve static files from the frontend directory
 const frontendPath = path.join(__dirname, '..', '..', 'frontend');
 app.use(express.static(frontendPath));
+
+app.use('/api', strainEditorService);
 
 // --- Simulation State ---
 let simulationState = {

--- a/src/server/services/strainEditorService.js
+++ b/src/server/services/strainEditorService.js
@@ -1,0 +1,90 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+import { createGzip } from 'zlib';
+import { pipeline } from 'stream/promises';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const strainsDir = path.join(__dirname, '..', '..', '..', 'data', 'strains');
+const backupDir = path.join(__dirname, '..', '..', '..', 'data', 'strain', 'backup');
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+ensureDir(strainsDir);
+ensureDir(backupDir);
+
+function timestamp() {
+  const d = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+}
+
+async function backupIfExists(id) {
+  const file = path.join(strainsDir, `${id}.json`);
+  if (fs.existsSync(file)) {
+    const dest = path.join(backupDir, `${id}-${timestamp()}.json.zip`);
+    await pipeline(
+      fs.createReadStream(file),
+      createGzip(),
+      fs.createWriteStream(dest)
+    );
+  }
+}
+
+router.get('/strains', (req, res) => {
+  try {
+    const files = fs.readdirSync(strainsDir).filter(f => f.endsWith('.json'));
+    const list = files.map(f => {
+      const data = JSON.parse(fs.readFileSync(path.join(strainsDir, f), 'utf8'));
+      return { id: data.id, name: data.name };
+    });
+    res.json(list);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.get('/strains/:id', (req, res) => {
+  const { id } = req.params;
+  const file = path.join(strainsDir, `${id}.json`);
+  if (!fs.existsSync(file)) return res.status(404).json({ error: 'Not found' });
+  try {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.post('/strains', async (req, res) => {
+  try {
+    const strain = req.body || {};
+    const id = strain.id || uuidv4();
+    strain.id = id;
+    await backupIfExists(id);
+    fs.writeFileSync(path.join(strainsDir, `${id}.json`), JSON.stringify(strain, null, 2));
+    res.status(201).json(strain);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.put('/strains/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const strain = { ...req.body, id };
+    await backupIfExists(id);
+    fs.writeFileSync(path.join(strainsDir, `${id}.json`), JSON.stringify(strain, null, 2));
+    res.json(strain);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Editor tab with Strain editor UI and routing
- implement server-side strain CRUD service with backups
- ignore strain backups from git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a008080c7483259be4236611798c88