### PR TITLE
feat: add REST simulation control API

### DIFF
--- a/src/server/simControlRoutes.js
+++ b/src/server/simControlRoutes.js
@@ -1,0 +1,41 @@
+import express from 'express';
+import cors from 'cors';
+
+export default function createSimControlRoutes(controller) {
+  const router = express.Router();
+  router.use(cors({ origin: 'http://localhost:5173' }));
+
+  router.get('/state', (req, res) => {
+    res.json(controller.getState());
+  });
+
+  router.post('/command', async (req, res) => {
+    const { type, steps, speed } = req.body || {};
+    try {
+      switch (type) {
+        case 'play':
+          await controller.play();
+          break;
+        case 'pause':
+          controller.pause();
+          break;
+        case 'step':
+          await controller.step(steps);
+          break;
+        case 'reset':
+          await controller.reset();
+          break;
+        case 'setSpeed':
+          controller.setSpeed(speed);
+          break;
+        default:
+          return res.status(400).json({ error: 'Invalid command type' });
+      }
+      res.json(controller.getState());
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- add simulation controller with play, pause, step, reset and speed control
- expose REST endpoints `/api/sim/state` and `/api/sim/command`
- ensure interval cleanup on server shutdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a070d9ae408325a64cc7589312cb88