### PR TITLE
fix: support zero day from backend

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -154,7 +154,7 @@ function updateWithLiveData(data) {
         simTime: newSimTime,
         balance: Number(data.balance),
         tickHours: Number(data.tickIntervalHours),
-        day: Number(data.day) || state.day,
+        day: Number(data.day ?? state.day),
         dailyEnergyKWh: Number(data.dailyEnergyKWh),
         dailyWaterL: Number(data.dailyWaterL),
         tickEnergyKWh: Number(data.energyKWh) || 0,


### PR DESCRIPTION
## Summary
- handle day zero from backend by using nullish coalescing

## Testing
- `npm test`
- `node - <<'NODE'
const state = {day: 5};
const data = {day: 0};
const result = Number(data.day ?? state.day);
console.log('day assigned:', result);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a1551f1a248325b25e1542a8674ffa