### PR TITLE
Fix WebSocket protocol based on page protocol

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -64,7 +64,8 @@ function ensureZoneSmoothers(zone) {
 }
 
 // --- WebSocket connection -------------------------------------------------
-const socket = new WebSocket(`ws://${window.location.host}`);
+const proto = window.location.protocol === "https:" ? "wss" : "ws";
+const socket = new WebSocket(`${proto}://${window.location.host}`);
 
 socket.onopen = () => {
     console.log("WebSocket connection established");


### PR DESCRIPTION
## Summary
- ensure WebSocket uses `wss` when page served over HTTPS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a15ffc68448325b0491ca402fc350f