### PR TITLE
Remove redundant script tags from frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,8 +139,6 @@
     </main>
   </div>
 
-  <script type="module" src="smoother.js"></script>
-  <script type="module" src="format.js"></script>
   <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove direct `smoother.js` and `format.js` module scripts from `frontend/index.html`
- leave only `main.js` module script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a161dc3ecc8325ab48ae093647e0c2