### PR TITLE
feat: gate live data logging behind debug flag

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,6 +1,8 @@
 import { makeSmooth } from "./smoother.js";
 import formatUnits from "./format.js";
 
+const DEBUG = false;
+
 // --- Helpers -------------------------------------------------------------
 const $ = (s, r = document) => r.querySelector(s);
 const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
@@ -118,7 +120,7 @@ async function fetchInitialData() {
 }
 
 function updateWithLiveData(data) {
-    console.log(JSON.stringify(data, null, 2));
+    if (DEBUG) console.debug('live', data);
     const newSimTime = new Date(data.isoTime);
 
     // Update live data in the structure data before state merge


### PR DESCRIPTION
## Summary
- add DEBUG flag to frontend
- wrap live data console output behind debug check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a163e39c048325abbc764ee6060b0f