### PR TITLE
feat: add React frontend scaffold

### DIFF
--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -163,6 +163,12 @@ High-level operational views for **Structure → Rooms → Zones → Plants**.
 - [frontend/main.js](../../frontend/main.js)
 - [frontend/editor/strainEditor.js](../../frontend/editor/strainEditor.js)
 
+## React-Frontend
+
+The React-based frontend lives in `frontend-react/` and is built with Vite. It uses a global `StateContext` with a reducer and a
+WebSocket-driven `useLiveData` hook for live simulation updates. The layout provides a left-hand mode navigation, a top bar with
+simulation controls, and a main content area that switches between Structure, Company, Editor and Shop views.
+
 ## Roadmap
 
 Planned views and features:

--- a/frontend-react/.gitignore
+++ b/frontend-react/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+dist-ssr
+*.local

--- a/frontend-react/index.html
+++ b/frontend-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weed Breed React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -1,0 +1,1 @@
+export { default } from './components/layout/App';

--- a/frontend-react/src/StateContext.tsx
+++ b/frontend-react/src/StateContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import { useLiveData } from './hooks/useLiveData';
+
+interface Selection {
+  structureId?: string;
+  roomId?: string;
+  zoneId?: string;
+  plantId?: string;
+}
+
+interface State {
+  treeMode: 'structure' | 'company' | 'shop' | 'editor';
+  selection: Selection;
+  tick: number;
+  balance: number;
+  dailyEnergyKWh: number;
+  running: boolean;
+  speed: string;
+}
+
+const initialState: State = {
+  treeMode: 'structure',
+  selection: {},
+  tick: 0,
+  balance: 0,
+  dailyEnergyKWh: 0,
+  running: false,
+  speed: 'normal',
+};
+
+type Action =
+  | { type: 'SET_STATE'; payload: Partial<State> }
+  | { type: 'UPDATE_LIVE'; payload: Partial<State> };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_STATE':
+      return { ...state, ...action.payload };
+    case 'UPDATE_LIVE':
+      return { ...state, ...action.payload };
+    default:
+      return state;
+  }
+}
+
+const Ctx = createContext<{ state: State; dispatch: React.Dispatch<Action> } | undefined>(undefined);
+
+export const StateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useLiveData(dispatch);
+
+  useEffect(() => {
+    fetchInitialData(dispatch);
+  }, []);
+
+  return <Ctx.Provider value={{ state, dispatch }}>{children}</Ctx.Provider>;
+};
+
+export function useAppState() {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAppState must be used within StateProvider');
+  return ctx;
+}
+
+async function fetchInitialData(dispatch: React.Dispatch<Action>) {
+  try {
+    const res = await fetch('/simulation/status');
+    if (res.ok) {
+      const data = await res.json();
+      dispatch({ type: 'SET_STATE', payload: updateWithLiveData(data) });
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function updateWithLiveData(data: any): Partial<State> {
+  return {
+    tick: data.tick ?? 0,
+    balance: data.balance ?? 0,
+    dailyEnergyKWh: data.dailyEnergyKWh ?? 0,
+    running: data.running ?? false,
+    speed: data.speed ?? 'normal',
+  };
+}

--- a/frontend-react/src/components/company/CompanyView.tsx
+++ b/frontend-react/src/components/company/CompanyView.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+const periods = ['24h', '7d', '1m'] as const;
+
+type Period = typeof periods[number];
+
+const CompanyView: React.FC = () => {
+  const [period, setPeriod] = useState<Period>('24h');
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Company View</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        {periods.map(p => (
+          <button key={p} onClick={() => setPeriod(p)} disabled={period === p} style={{ marginRight: 4 }}>
+            {p}
+          </button>
+        ))}
+      </div>
+      {/* TODO: Charts and tables for consumption & costs */}
+    </div>
+  );
+};
+
+export default CompanyView;

--- a/frontend-react/src/components/editor/StrainEditor.tsx
+++ b/frontend-react/src/components/editor/StrainEditor.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+
+interface Strain {
+  id: string;
+  name: string;
+  generalResilience: number;
+  genotype: { sativa: number; indica: number; ruderalis: number };
+  lineage: { parents: string[] };
+}
+
+const emptyStrain: Strain = {
+  id: '',
+  name: '',
+  generalResilience: 0,
+  genotype: { sativa: 0, indica: 0, ruderalis: 0 },
+  lineage: { parents: [] }
+};
+
+const StrainEditor: React.FC = () => {
+  const [strains, setStrains] = useState<Strain[]>([]);
+  const [current, setCurrent] = useState<Strain>(emptyStrain);
+
+  useEffect(() => {
+    loadList();
+  }, []);
+
+  async function loadList() {
+    try {
+      const res = await fetch('/api/strains');
+      if (res.ok) {
+        const data = await res.json();
+        setStrains(data);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function loadStrain(id: string) {
+    try {
+      const res = await fetch(`/api/strains/${id}`);
+      if (res.ok) {
+        const s = await res.json();
+        setCurrent({
+          id: s.id,
+          name: s.name,
+          generalResilience: s.generalResilience ?? 0,
+          genotype: {
+            sativa: s.genotype?.sativa ?? 0,
+            indica: s.genotype?.indica ?? 0,
+            ruderalis: s.genotype?.ruderalis ?? 0,
+          },
+          lineage: { parents: s.lineage?.parents ?? [] },
+        });
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function newStrain() {
+    setCurrent({ ...emptyStrain, id: crypto.randomUUID() });
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    const url = current.id ? `/api/strains/${current.id}` : '/api/strains';
+    const method = current.id ? 'PUT' : 'POST';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(current),
+    });
+    await loadList();
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Strain Editor</h2>
+      <div style={{ display: 'flex', gap: '2rem' }}>
+        <form onSubmit={save} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <label>
+            ID
+            <input value={current.id} readOnly />
+          </label>
+          <label>
+            Name*
+            <input value={current.name} onChange={e => setCurrent({ ...current, name: e.target.value })} required />
+          </label>
+          <label>
+            Resilience*
+            <input type="number" step="0.01" value={current.generalResilience} onChange={e => setCurrent({ ...current, generalResilience: Number(e.target.value) })} />
+          </label>
+          <div>
+            Genotype*
+            <div style={{ display: 'flex', gap: 4 }}>
+              <input type="number" step="0.01" placeholder="Sativa" value={current.genotype.sativa} onChange={e => setCurrent({ ...current, genotype: { ...current.genotype, sativa: Number(e.target.value) } })} />
+              <input type="number" step="0.01" placeholder="Indica" value={current.genotype.indica} onChange={e => setCurrent({ ...current, genotype: { ...current.genotype, indica: Number(e.target.value) } })} />
+              <input type="number" step="0.01" placeholder="Ruderalis" value={current.genotype.ruderalis} onChange={e => setCurrent({ ...current, genotype: { ...current.genotype, ruderalis: Number(e.target.value) } })} />
+            </div>
+          </div>
+          <label>
+            Parents
+            <select multiple size={5} value={current.lineage.parents} onChange={e => {
+              const selected = Array.from(e.target.selectedOptions).map(o => o.value);
+              setCurrent({ ...current, lineage: { parents: selected } });
+            }}>
+              {strains.map(s => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+          </label>
+          <div>
+            <button type="submit">Save</button>
+            <button type="button" onClick={newStrain}>New</button>
+          </div>
+        </form>
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {strains.map(s => (
+            <li key={s.id}>
+              <button onClick={() => loadStrain(s.id)}>{s.name}</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default StrainEditor;

--- a/frontend-react/src/components/layout/App.tsx
+++ b/frontend-react/src/components/layout/App.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import LeftPanel from './LeftPanel';
+import TopBar from './TopBar';
+import MainContent from './MainContent';
+
+const App: React.FC = () => (
+  <div style={{ display: 'flex', height: '100vh' }}>
+    <LeftPanel />
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <TopBar />
+      <MainContent />
+    </div>
+  </div>
+);
+
+export default App;

--- a/frontend-react/src/components/layout/LeftPanel.tsx
+++ b/frontend-react/src/components/layout/LeftPanel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+
+const modes = ['structure', 'company', 'shop', 'editor'] as const;
+
+const LeftPanel: React.FC = () => {
+  const { state, dispatch } = useAppState();
+  return (
+    <aside style={{ width: 200, borderRight: '1px solid #ccc', padding: '0.5rem' }}>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {modes.map((m) => (
+          <li key={m} style={{ marginBottom: 4 }}>
+            <button
+              style={{
+                width: '100%',
+                padding: '0.25rem',
+                background: state.treeMode === m ? '#ddd' : 'transparent',
+                border: '1px solid #ccc'
+              }}
+              onClick={() => dispatch({ type: 'SET_STATE', payload: { treeMode: m, selection: {} } })}
+            >
+              {m}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default LeftPanel;

--- a/frontend-react/src/components/layout/MainContent.tsx
+++ b/frontend-react/src/components/layout/MainContent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+import StructureView from '../structure/StructureView';
+import CompanyView from '../company/CompanyView';
+import StrainEditor from '../editor/StrainEditor';
+import ShopPlaceholder from '../shop/ShopPlaceholder';
+
+const MainContent: React.FC = () => {
+  const { state } = useAppState();
+  switch (state.treeMode) {
+    case 'structure':
+      return <StructureView />;
+    case 'company':
+      return <CompanyView />;
+    case 'editor':
+      return <StrainEditor />;
+    case 'shop':
+    default:
+      return <ShopPlaceholder />;
+  }
+};
+
+export default MainContent;

--- a/frontend-react/src/components/layout/TopBar.tsx
+++ b/frontend-react/src/components/layout/TopBar.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+import formatUnits from '../../utils/formatUnits';
+
+const TopBar: React.FC = () => {
+  const { state, dispatch } = useAppState();
+
+  const setRunning = async (running: boolean) => {
+    try {
+      await fetch(`/simulation/${running ? 'start' : 'pause'}`, { method: 'POST' });
+      dispatch({ type: 'SET_STATE', payload: { running } });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const changeSpeed = async (speed: string) => {
+    try {
+      await fetch(`/simulation/speed/${speed}`, { method: 'POST' });
+      dispatch({ type: 'SET_STATE', payload: { speed } });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <header style={{ display: 'flex', justifyContent: 'space-between', padding: '0.5rem', borderBottom: '1px solid #ccc' }}>
+      <div>
+        Tick: {state.tick} | Balance: €{state.balance.toFixed(2)} | Daily: {formatUnits(state.dailyEnergyKWh, 'kWh')}
+      </div>
+      <div>
+        <button onClick={() => setRunning(true)} disabled={state.running}>Start</button>
+        <button onClick={() => setRunning(false)} disabled={!state.running}>Pause</button>
+        <select value={state.speed} onChange={e => changeSpeed(e.target.value)}>
+          <option value="slow">slow</option>
+          <option value="normal">normal</option>
+          <option value="fast">fast</option>
+        </select>
+      </div>
+    </header>
+  );
+};
+
+export default TopBar;

--- a/frontend-react/src/components/shop/ShopPlaceholder.tsx
+++ b/frontend-react/src/components/shop/ShopPlaceholder.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const ShopPlaceholder: React.FC = () => (
+  <div style={{ padding: '1rem' }}>
+    <h2>Shop</h2>
+    <p>Shop view is not implemented yet.</p>
+  </div>
+);
+
+export default ShopPlaceholder;

--- a/frontend-react/src/components/structure/PlantView.tsx
+++ b/frontend-react/src/components/structure/PlantView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+
+const PlantView: React.FC = () => {
+  const { state } = useAppState();
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Plant View</h2>
+      <p>Selected Plant: {state.selection.plantId ?? 'none'}</p>
+      {/* TODO: Plant detail */}
+    </div>
+  );
+};
+
+export default PlantView;

--- a/frontend-react/src/components/structure/RoomView.tsx
+++ b/frontend-react/src/components/structure/RoomView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+
+const RoomView: React.FC = () => {
+  const { state } = useAppState();
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Room View</h2>
+      <p>Selected Room: {state.selection.roomId ?? 'none'}</p>
+      {/* TODO: KPIs and Zones table */}
+    </div>
+  );
+};
+
+export default RoomView;

--- a/frontend-react/src/components/structure/StructureView.tsx
+++ b/frontend-react/src/components/structure/StructureView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+
+const StructureView: React.FC = () => {
+  const { state } = useAppState();
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Structure View</h2>
+      <p>Selected Structure: {state.selection.structureId ?? 'none'}</p>
+      {/* TODO: KPIs and Rooms table */}
+    </div>
+  );
+};
+
+export default StructureView;

--- a/frontend-react/src/components/structure/ZoneView.tsx
+++ b/frontend-react/src/components/structure/ZoneView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useAppState } from '../../StateContext';
+
+const ZoneView: React.FC = () => {
+  const { state } = useAppState();
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Zone View</h2>
+      <p>Selected Zone: {state.selection.zoneId ?? 'none'}</p>
+      {/* TODO: KPIs and details */}
+    </div>
+  );
+};
+
+export default ZoneView;

--- a/frontend-react/src/hooks/useLiveData.ts
+++ b/frontend-react/src/hooks/useLiveData.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export function useLiveData(dispatch: (action: any) => void) {
+  useEffect(() => {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${window.location.host}`);
+    ws.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        dispatch({ type: 'UPDATE_LIVE', payload: data });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    return () => ws.close();
+  }, [dispatch]);
+}

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { StateProvider } from './StateContext';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <StateProvider>
+      <App />
+    </StateProvider>
+  </React.StrictMode>
+);

--- a/frontend-react/src/utils/formatUnits.ts
+++ b/frontend-react/src/utils/formatUnits.ts
@@ -1,0 +1,31 @@
+export default function formatUnits(value: number | string, type: 'grams' | 'kWh' | 'liters'): string {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return '-';
+  }
+  let val = num;
+  const scales = {
+    grams: [
+      { limit: 1e6, divisor: 1e6, unit: 't' },
+      { limit: 1e3, divisor: 1e3, unit: 'kg' },
+      { limit: 0, divisor: 1, unit: 'g' },
+    ],
+    kWh: [
+      { limit: 1e6, divisor: 1e6, unit: 'GWh' },
+      { limit: 1e3, divisor: 1e3, unit: 'MWh' },
+      { limit: 0, divisor: 1, unit: 'kWh' },
+    ],
+    liters: [
+      { limit: 1e3, divisor: 1e3, unit: 'm³' },
+      { limit: 0, divisor: 1, unit: 'L' },
+    ],
+  } as const;
+
+  const scale = scales[type];
+  for (const { limit, divisor, unit } of scale) {
+    if (val >= limit) {
+      return `${(val / divisor).toFixed(2)} ${unit}`;
+    }
+  }
+  return `${val.toFixed(2)}`;
+}

--- a/frontend-react/src/utils/smoother.ts
+++ b/frontend-react/src/utils/smoother.ts
@@ -1,0 +1,73 @@
+import { useRef } from 'react';
+
+export function makeSmoother({
+  alpha = 0.2,
+  deadband = 0.05,
+  step = 0.01,
+  minUpdateMs = 120,
+  maxUpdateMs = 800,
+  maxSlewPerSec = Infinity
+} = {}) {
+  let ema: number | null = null;
+  let shown: number | null = null;
+  let lastEmit = 0;
+
+  return function next(rawValue: number, now = (typeof performance !== 'undefined' ? performance.now() : Date.now())) {
+    ema = ema == null ? rawValue : (1 - alpha) * ema + alpha * rawValue;
+
+    let target = ema;
+    if (shown != null && isFinite(maxSlewPerSec)) {
+      const dt = Math.max(1, now - lastEmit) / 1000;
+      const maxDelta = maxSlewPerSec * dt;
+      const diff = ema - shown;
+      if (Math.abs(diff) > maxDelta) target = shown + Math.sign(diff) * maxDelta;
+    }
+
+    const quant = step > 0 ? Math.round(target / step) * step : target;
+
+    const timeSince = now - lastEmit;
+    const mustEmit =
+      shown == null ||
+      Math.abs(quant - shown) >= deadband ||
+      timeSince >= maxUpdateMs ||
+      (timeSince >= minUpdateMs && Math.abs(quant - shown) > 0);
+
+    if (mustEmit) {
+      shown = quant;
+      lastEmit = now;
+      return shown;
+    }
+    return null;
+  };
+}
+
+export function makeSmooth({ windowHours = 24 } = {}) {
+  const windowMs = windowHours * 3600 * 1000;
+  const samples: { t: number; v: number }[] = [];
+  let sum = 0;
+
+  return function next(value: number, now = Date.now()) {
+    samples.push({ t: now, v: value });
+    sum += value;
+    while (samples.length && now - samples[0].t > windowMs) {
+      sum -= samples.shift()!.v;
+    }
+    return samples.length ? sum / samples.length : 0;
+  };
+}
+
+export function useSmoother(options?: Parameters<typeof makeSmoother>[0]) {
+  const ref = useRef<ReturnType<typeof makeSmoother>>();
+  if (!ref.current) {
+    ref.current = makeSmoother(options ?? {});
+  }
+  return ref.current;
+}
+
+export function useSmooth(options?: Parameters<typeof makeSmooth>[0]) {
+  const ref = useRef<ReturnType<typeof makeSmooth>>();
+  if (!ref.current) {
+    ref.current = makeSmooth(options ?? {});
+  }
+  return ref.current;
+}

--- a/frontend-react/tsconfig.json
+++ b/frontend-react/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend-react/tsconfig.node.json
+++ b/frontend-react/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/simulation': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- set up `frontend-react` Vite project with proxy and TypeScript
- implement global `StateContext` with WebSocket live updates
- add layout, structure/company/editor/shop views and utilities
- document React frontend in overview

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build` *(fails: TS2307 Cannot find module 'react')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a179aa5fcc832580ddb23fa3fd0ac0