### PR TITLE
docs: add setup instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This folder provides an overview of the Weed Breed simulation game. The project simulates cannabis cultivation using a tick-based engine.
 
+For setup instructions and running the project, see [Setup](setup.md).
+
 ## Directory Structure
 
 - [Architecture](architecture/overview.md) – high level system design and references to key modules. See also the [ADRs](architecture/adr/) for individual decisions.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,25 @@
+# Setup
+
+## Voraussetzungen
+
+- Node.js v22.18.0
+- npm v11.4.2
+- keine weiteren globalen Tools notwendig
+
+## Installation
+
+```bash
+git clone <REPO_URL>
+cd weed-breed-js
+npm install
+```
+
+## Starten
+
+- Simulation: `npm run sim`
+- Server mit Hot Reload: `npm run dev`
+
+## Standard-Umgebungsvariablen
+
+- `PORT` – Port des Servers, Standardwert `3000`
+- `SSE_ALLOW_ORIGIN` – erlaubter Origin für Server-Sent Events, Standardwert `http://localhost:5173`


### PR DESCRIPTION
## Summary
- add setup guide outlining Node.js 22.18.0, npm 11.4.2, install steps, start commands, and default env vars
- link new setup guide from documentation overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a238ef35f88325bf387ac1a92b9d97