### PR TITLE
Refine humidity and CO₂ modeling

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -9,7 +9,8 @@ export const env = {
   physics: {
     // Air (at approx. 20–25°C)
     airDensity: 1.2,   // kg/m³
-    airCp: 1005        // J/(kg·K) – specific heat capacity
+    airCp: 1005,       // J/(kg·K) – specific heat capacity
+    airMolarDensityMolPerM3: 41.6 // mol/m³ at ~20 °C
   },
   factors: {
     kwToW: 1000,       // kW → W
@@ -21,6 +22,8 @@ export const env = {
     passiveUaPerM2: 0.5,          // W/(m²·K) – Passive heat transfer per m² of shell area
     airChangesPerHour: 0.3,       // simple leakage to the outside
     outsideTemperatureC: 22,      // Outside temperature
+    outsideHumidity: 0.5,         // Outside RH (0..1)
+    outsideCo2ppm: 420,           // Outside CO₂
     temperatureC: 24,             // Start temperature
     humidity: 0.6,                // Start RH (0..1)
     co2ppm: 420,                  // Start CO₂
@@ -31,8 +34,9 @@ export const env = {
   },
   humidity: {
     // Moisture pool model: Mv_max = moistureRefKgPerM3 * volume
-    moistureRefKgPerM3: 0.0003,   // kg/m³ (tunable)
-    alpha: 1.0                    // Normalization RH = alpha * (Mv/MvMax)
+    moistureRefKgPerM3: 0.017,   // kg/m³ at 20 °C (saturation)
+    alpha: 1.0,                  // Normalization RH = alpha * (Mv/MvMax)
+    deriveFromTemperature: true  // adjust saturation with temperature
   },
   clamps: {
     humidityMin: 0.30,
@@ -53,6 +57,7 @@ export const env = {
     rhOpt: 0.6,
     rhWidth: 0.4,
     co2KappaA: 1.0,               // ppm/tick per (A*LAI)
+    maxAssimilationMolPerM2PerS: 30e-6, // mol CO₂/m²/s at A=1
 
     // Biology & Yield
     geneticVariance: 0.2,         // +/- 10% genetic variance (0.2 = 20%)
@@ -73,3 +78,17 @@ export const HOUR_TO_SEC = env.factors.hourToSec;
 export const OUTDOOR_TEMP_C = env.defaults.outsideTemperatureC;
 export const THERMAL_MASS_MULTIPLIER = env.defaults.thermalMassMultiplier;
 export const PASSIVE_UA_PER_M2 = env.defaults.passiveUaPerM2;
+
+/**
+ * Approximate saturation humidity (water vapor density) for a given temperature.
+ * Uses the Magnus formula. Returns kg H₂O per m³ of air.
+ * @param {number} tC - Temperature in °C
+ * @returns {number} kg/m³
+ */
+export function saturationMoistureKgPerM3(tC = 20) {
+  const t = Number(tC);
+  const es = 610.94 * Math.exp((17.625 * t) / (243.04 + t)); // Pa
+  const Rv = 461.5; // J/(kg·K)
+  const Tk = t + 273.15; // K
+  return es / (Rv * Tk);
+}

--- a/src/engine/devices/HumidityControlUnit.js
+++ b/src/engine/devices/HumidityControlUnit.js
@@ -1,7 +1,7 @@
 // src/engine/devices/HumidityControlUnit.js
 import { BaseDevice } from '../BaseDevice.js';
-import { ensureEnv, addLatentWater } from '../deviceUtils.js';
-import { env } from '../../config/env.js';
+import { ensureEnv, addLatentWater, getZoneVolume } from '../deviceUtils.js';
+import { env, saturationMoistureKgPerM3 } from '../../config/env.js';
 import { resolveTickHours } from '../../lib/time.js';
 
 export class HumidityControlUnit extends BaseDevice {
@@ -17,22 +17,38 @@ export class HumidityControlUnit extends BaseDevice {
     const hyst = Number(settings.hysteresis ?? 0.05);
     const now = Number(s.humidity ?? target);
 
+    // determine desired state
     this.state = 'idle';
-    if (now > target + hyst * 0.5) {
-        this.state = 'dehumidifying';
+    if (now > target + hyst * 0.5) this.state = 'dehumidifying';
+    if (now < target - hyst * 0.5) this.state = 'humidifying';
+
+    // compute moisture delta to reach target
+    const vol = getZoneVolume(zone);
+    const tempC = Number(s.temperature ?? env.defaults.temperatureC ?? 20);
+    let mRef = Number(env.humidity.moistureRefKgPerM3 ?? 0.017);
+    if (env.humidity.deriveFromTemperature) {
+      mRef = saturationMoistureKgPerM3(tempC);
     }
-    if (now < target - hyst * 0.5) {
-        this.state = 'humidifying';
-    }
+    const alpha = Number(env.humidity.alpha ?? 1);
+    const MvMax = Math.max(1e-9, mRef * vol);
+    const Mv = Number(s.moistureKg ?? 0);
+    const rhNorm = Math.min(1, Math.max(0, target / alpha));
+    const MvTarget = rhNorm * MvMax;
+    const moistureDelta = MvTarget - Mv; // kg required (+ humidify)
+
+    const maxFrac = Math.max(0, Math.min(1, Number(settings.maxRateFraction ?? 0.1)));
+    const needed = Math.abs(moistureDelta);
+    const permitted = needed * maxFrac;
 
     if (this.state === 'dehumidifying') {
-      const kg = Number(settings.dehumidifyRateKgPerTick ?? 0);
+      const rate = Number(settings.dehumidifyRateKgPerTick ?? 0);
+      const kg = Math.min(rate, needed, permitted);
       if (kg > 0) addLatentWater(s, -kg);
     } else if (this.state === 'humidifying') {
-      const kg = Number(settings.humidifyRateKgPerTick ?? 0);
+      const rate = Number(settings.humidifyRateKgPerTick ?? 0);
+      const kg = Math.min(rate, needed, permitted);
       if (kg > 0) {
         addLatentWater(s, kg);
-        // book water usage via cost engine if available
         this.runtimeCtx?.zone?.costEngine?.bookWater(kg, { zoneId: this.runtimeCtx?.zone?.id, deviceId: this.id });
       }
     }

--- a/tests/humidityControlUnit.test.js
+++ b/tests/humidityControlUnit.test.js
@@ -1,32 +1,44 @@
 import { HumidityControlUnit } from '../src/engine/devices/HumidityControlUnit.js';
-import { ensureEnv } from '../src/engine/deviceUtils.js';
+import { ensureEnv, getZoneVolume } from '../src/engine/deviceUtils.js';
+import { env as cfg, saturationMoistureKgPerM3 } from '../src/config/env.js';
 import { jest } from '@jest/globals';
 
 describe('HumidityControlUnit', () => {
   function setup(humidity) {
     const costEngine = { bookWater: jest.fn() };
-    const zone = { id: 'z1', costEngine };
+    const zone = { id: 'z1', costEngine, area: 1, height: 2.5 };
     const env = ensureEnv(zone);
     env.humidity = humidity;
+    const mRef = cfg.humidity.deriveFromTemperature
+      ? saturationMoistureKgPerM3(env.temperature)
+      : cfg.humidity.moistureRefKgPerM3;
+    const vol = getZoneVolume(zone);
+    env.moistureKg = humidity * mRef * vol;
     const runtimeCtx = { zone, tickLengthInHours: 1 };
-    return { zone, env, runtimeCtx, costEngine };
+    return { zone, env, runtimeCtx, costEngine, mRef, vol };
   }
 
   it('dehumidifies when above threshold', () => {
-    const { zone, env, runtimeCtx } = setup(0.8);
+    const { zone, env, runtimeCtx, mRef, vol } = setup(0.8);
     const unit = new HumidityControlUnit({ id: 'h1', kind: 'HumidityControlUnit', settings: { targetHumidity: 0.6, hysteresis: 0.1, dehumidifyRateKgPerTick: 0.05 } }, runtimeCtx);
     unit.applyEffect(zone);
     expect(unit.state).toBe('dehumidifying');
-    expect(env._waterKgDelta).toBeCloseTo(-0.05);
+    const needed = 0.2 * mRef * vol;
+    const expected = -needed * 0.1;
+    expect(env._waterKgDelta).toBeCloseTo(expected, 5);
   });
 
   it('humidifies and books water when below threshold', () => {
-    const { zone, env, runtimeCtx, costEngine } = setup(0.4);
+    const { zone, env, runtimeCtx, costEngine, mRef, vol } = setup(0.4);
     const unit = new HumidityControlUnit({ id: 'h1', kind: 'HumidityControlUnit', settings: { targetHumidity: 0.6, hysteresis: 0.1, humidifyRateKgPerTick: 0.03 } }, runtimeCtx);
     unit.applyEffect(zone);
     expect(unit.state).toBe('humidifying');
-    expect(env._waterKgDelta).toBeCloseTo(0.03);
-    expect(costEngine.bookWater).toHaveBeenCalledWith(0.03, { zoneId: zone.id, deviceId: unit.id });
+    const needed = 0.2 * mRef * vol;
+    const expected = needed * 0.1;
+    expect(env._waterKgDelta).toBeCloseTo(expected, 5);
+    expect(costEngine.bookWater).toHaveBeenCalledTimes(1);
+    const booked = costEngine.bookWater.mock.calls[0][0];
+    expect(booked).toBeCloseTo(expected, 5);
   });
 
   it('stays idle within hysteresis band', () => {


### PR DESCRIPTION
## Summary
- limit humidifier/dehumidifier output based on required moisture delta
- track CO₂ uptake in moles and mix humidity/CO₂ with outside air each tick
- add realistic humidity references, air molar density and outside defaults

## Testing
- `npm test`
- `LOG_LEVEL=silent node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a2be31167c8325bf18c080058827e6