### PR TITLE
feat: preserve plant death stressors

### DIFF
--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -72,6 +72,7 @@ export class Plant {
     this.causeOfDeath = null;
     this.stageTimeHours = 0;
     this.lightHours = 0;
+    this.deathLog = [];
   }
 
   /**
@@ -195,18 +196,21 @@ export class Plant {
     this.health = Math.max(0, Math.min(1, this.health));
 
     if (this.health <= 0) {
+      if (!this.isDead) {
+        let dominant = null;
+        let max = -Infinity;
+        for (const [k, v] of Object.entries(this.stressors)) {
+          const sev = v?.severity ?? 0;
+          if (sev > max) {
+            max = sev;
+            dominant = k;
+          }
+        }
+        this.causeOfDeath = dominant ?? 'unknown';
+        this.deathLog.push({ tick: tickIndex, stressors: { ...this.stressors }, cause: this.causeOfDeath });
+      }
       this.isDead = true;
       this.stage = 'dead';
-      let dominant = null;
-      let max = -Infinity;
-      for (const [k, v] of Object.entries(this.stressors)) {
-        const sev = v?.severity ?? 0;
-        if (sev > max) {
-          max = sev;
-          dominant = k;
-        }
-      }
-      this.causeOfDeath = dominant ?? 'unknown';
       return;
     }
 
@@ -239,6 +243,10 @@ export class Plant {
     }
 
     this.updateBiomass({ zone });
+  }
+
+  getDeathLog() {
+    return this.deathLog;
   }
 
   getPhase() {

--- a/src/server/services/plantDetailService.js
+++ b/src/server/services/plantDetailService.js
@@ -58,6 +58,7 @@ export function createPlantDetailDTO(zone, plant) {
         ageDays: Math.floor(p.ageHours / 24),
         health: Number((p.health * 100).toFixed(1)),
         stress: Number((p.stress * 100).toFixed(1)),
+        deathLog: p.getDeathLog ? p.getDeathLog() : (p.deathLog || []),
     }));
 
     return { environment, stressFactors, plants };


### PR DESCRIPTION
## Summary
- store per-tick stressors in `deathLog` when a plant dies
- expose `deathLog` via `Plant.getDeathLog()`
- include `deathLog` in plant detail DTO for post-mortem analysis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e02ccfb88325b3aaa7e41636c977