### PR TITLE
Model yield from biomass and track plant mortality

### DIFF
--- a/src/sim/StatsCollector.js
+++ b/src/sim/StatsCollector.js
@@ -5,6 +5,7 @@ export class StatsCollector {
     this.zones = new Map(zones.map(z => [z.id, z]));
     this.totalBuds_g = 0;
     this.totalBiomass_g = 0;
+    this.totalDeadPlants = 0;
     this.zoneTotals = {};
 
     events$.subscribe(e => {
@@ -24,11 +25,15 @@ export class StatsCollector {
       buds += plant.state?.biomassPartition?.buds_g ?? 0;
       biomass += plant.state?.biomassFresh_g ?? 0;
     }
+    const deaths = Object.values(zone.deathStats ?? {}).reduce((s, v) => s + v, 0);
+    const zt = this.zoneTotals[zone.id] ?? { buds_g: 0, biomass_g: 0, deaths: 0 };
     this.totalBuds_g += buds;
     this.totalBiomass_g += biomass;
-    const zt = this.zoneTotals[zone.id] ?? { buds_g: 0, biomass_g: 0 };
+    const newDeaths = deaths - (zt.deaths || 0);
+    this.totalDeadPlants += newDeaths;
     zt.buds_g += buds;
     zt.biomass_g += biomass;
+    zt.deaths = deaths;
     this.zoneTotals[zone.id] = zt;
   }
 
@@ -36,6 +41,7 @@ export class StatsCollector {
     return {
       totalBuds_g: this.totalBuds_g,
       totalBiomass_g: this.totalBiomass_g,
+      totalDeadPlants: this.totalDeadPlants,
       zones: this.zoneTotals
     };
   }


### PR DESCRIPTION
## Summary
- compute plant yield from bud biomass and stress-adjusted quality
- add biomass accessors and stress-based mortality probability
- track total biomass and deaths via StatsCollector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32355149083258713b6654809128a