### PR TITLE
Configure 730-day simulation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,13 @@ import { resolveTickHours } from './lib/time.js';
 
 // --- Main -------------------------------------------------------------------
 async function main() {
-  const { zones, costEngine, tickMachineLogic } = await initializeSimulation();
+  const { zones, costEngine, tickMachineLogic } = await initializeSimulation('default');
 
-  // Simulation run for this zone
-  const durationTicks = 840; // 105 days, static for now
+  // Simulation duration derived from tick length
   const tickLengthInHours = resolveTickHours(zones[0]);
   const ticksPerDay = Math.round(24 / tickLengthInHours);
+  const simDays = Number(process.env.SIM_DAYS) || 730;
+  const durationTicks = simDays * ticksPerDay;
 
   logger.info(`--- STARTING SIMULATION (1 tick = ${tickLengthInHours}h, 1 day = ${ticksPerDay} ticks) ---`);
 


### PR DESCRIPTION
### Summary
- derive simulation duration from tick length, defaulting to 730 days
- allow override via `SIM_DAYS` env var and explicitly use default savegame

### Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3378033cc8325a7e9a9714b7d1c59