### PR TITLE
feat: initialize rng in entry points

### DIFF
--- a/src/engine/loaders/difficultyLoader.js
+++ b/src/engine/loaders/difficultyLoader.js
@@ -1,4 +1,3 @@
-import fs from 'fs/promises';
 /**
  * Loader for difficulty configuration settings.
  * @module engine/loaders/difficultyLoader

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,15 @@ import { emit } from './sim/eventBus.js';
 import { createActor } from 'xstate';
 import { initializeSimulation } from './sim/simulation.js';
 import { resolveTickHours } from './lib/time.js';
+import { createRng } from './lib/rng.js';
 
 // --- Main -------------------------------------------------------------------
 /**
  * Run the simulation for a predefined duration.
  */
 async function main() {
+  const rng = createRng();
+  logger.debug({ sample: rng.float() }, 'Initialized RNG');
   const { zones, costEngine, tickMachineLogic } = await initializeSimulation('default');
 
   // Simulation duration derived from tick length

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -16,6 +16,7 @@ import { uiStream$ } from '../sim/eventBus.js';
 import { initializeSimulation } from '../sim/simulation.js';
 import strainEditorService from './services/strainEditorService.js';
 import createSimControlRoutes from './simControlRoutes.js';
+import { createRng } from '../lib/rng.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,7 +56,7 @@ app.get('/sse', (req, res) => {
 let simulationState = {
   structure: null,
   costEngine: null,
-  rng: null,
+  rng: createRng(),
   tickMachineLogic: null,
   intervalId: null,
   status: 'stopped', // 'running', 'paused'


### PR DESCRIPTION
## Summary
- import and initialize RNG in standalone simulation entry
- wire up RNG in server entry and seed default instance
- remove duplicate fs import in difficulty loader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33e31776c83259eca73b22778ce0c