### PR TITLE
Handle missing water and nutrient data to ensure harvest revenue

### DIFF
--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -379,11 +379,15 @@ function co2Factor(ppm) {
 }
 
 function waterFactor(coverage = 1) {
-  return clamp(0.3, Number(coverage), 1.0);
+  const c = Number(coverage);
+  if (!Number.isFinite(c)) return 1;
+  return clamp(0.3, c, 1.0);
 }
 
 function npkFactor(coverage = 1) {
-  return clamp(0.5, 0.5 + 0.5 * Number(coverage), 1.0);
+  const c = Number(coverage);
+  if (!Number.isFinite(c)) return 1;
+  return clamp(0.5, 0.5 + 0.5 * c, 1.0);
 }
 
 function rhFactor(rh = 0.6) {

--- a/tests/harvestRevenue.test.js
+++ b/tests/harvestRevenue.test.js
@@ -1,0 +1,22 @@
+import { Zone } from '../src/engine/Zone.js';
+import { Plant } from '../src/engine/Plant.js';
+import { CostEngine } from '../src/engine/CostEngine.js';
+import { createRng } from '../src/lib/rng.js';
+
+describe('Harvest revenue', () => {
+  test('books revenue when plants are harvested', () => {
+    const strainId = 's1';
+    const strainPriceMap = new Map([[strainId, { seedPrice: 0, harvestPricePerGram: 5 }]]);
+    const costEngine = new CostEngine({ strainPriceMap });
+    costEngine.startTick(0);
+    const rng = createRng('seed');
+    const zone = new Zone({ id: 'z1', runtime: { costEngine, rng, strainPriceMap } });
+    const plant = new Plant({ strain: { id: strainId }, stage: 'harvestReady' });
+    plant.state.biomassPartition.buds_g = 10; // 10 g yield
+    zone.addPlant(plant);
+
+    zone.harvestAndInventory();
+    const totals = costEngine.getTotals();
+    expect(totals.revenueEUR).toBeCloseTo(50); // 10 g * 5 EUR
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent water and nutrient growth factors from producing NaN when data is missing
- Add unit test confirming harvest directly books revenue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37ed3b1988325b307942e98388dc6