### PR TITLE
Read PPFD from zone environment

### DIFF
--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -295,7 +295,7 @@ export class Plant {
     const h = Number(zone.tickLengthInHours ?? ctx.tickLengthInHours ?? 1);
 
     // -- Light driven potential growth --
-    const DLI = this.getDailyLightIntegral(zone.ppfd ?? 0, h); // mol/m²/tick
+    const DLI = this.getDailyLightIntegral(zone.environment?.ppfd ?? 0, h); // mol/m²/tick
 
     const strain = this.strain ?? {};
     const phase = this.getPhase();

--- a/tests/plantBiomass.test.js
+++ b/tests/plantBiomass.test.js
@@ -7,18 +7,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const strainData = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/strains/ak-47.json'), 'utf8'));
 
 function makeCtx(overrides = {}) {
-  return {
-    zone: {
-      ppfd: 600,
-      tickLengthInHours: 1,
-      temperatureC: 25,
-      co2ppm: 1200,
-      humidity: 0.6,
-      water: 1,
-      npk: 1,
-      ...overrides,
-    },
+  const zone = {
+    tickLengthInHours: 1,
+    temperatureC: 25,
+    co2ppm: 1200,
+    humidity: 0.6,
+    water: 1,
+    npk: 1,
+    ...overrides,
   };
+  zone.environment = { ppfd: 600, ...(overrides.environment ?? {}) };
+  if (overrides.ppfd != null) zone.environment.ppfd = overrides.ppfd;
+  delete zone.ppfd;
+  return { zone };
 }
 
 describe('Plant biomass model', () => {


### PR DESCRIPTION
## Summary
- Calculate plant biomass using `zone.environment.ppfd` instead of a flat `zone.ppfd`
- Adjust biomass tests to supply PPFD via `zone.environment`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3eab4d2b4832581d89a93f93af0fc