### PR TITLE
Fix StatsCollector to snapshot biomass totals

### DIFF
--- a/src/sim/StatsCollector.js
+++ b/src/sim/StatsCollector.js
@@ -40,15 +40,17 @@ export class StatsCollector {
       biomass += plant.state?.biomassFresh_g ?? 0;
     }
     const deaths = Object.values(zone.deathStats ?? {}).reduce((s, v) => s + v, 0);
-    const zt = this.zoneTotals[zone.id] ?? { buds_g: 0, biomass_g: 0, deaths: 0 };
-    this.totalBuds_g += buds;
-    this.totalBiomass_g += biomass;
-    const newDeaths = deaths - (zt.deaths || 0);
+    const prev = this.zoneTotals[zone.id] ?? { buds_g: 0, biomass_g: 0, deaths: 0 };
+    const newDeaths = deaths - (prev.deaths || 0);
     this.totalDeadPlants += newDeaths;
-    zt.buds_g += buds;
-    zt.biomass_g += biomass;
-    zt.deaths = deaths;
-    this.zoneTotals[zone.id] = zt;
+    this.zoneTotals[zone.id] = { buds_g: buds, biomass_g: biomass, deaths };
+    // Recalculate global totals based on current zone snapshots
+    this.totalBuds_g = 0;
+    this.totalBiomass_g = 0;
+    for (const z of Object.values(this.zoneTotals)) {
+      this.totalBuds_g += z.buds_g;
+      this.totalBiomass_g += z.biomass_g;
+    }
   }
 
   /**

--- a/tests/statsCollector.test.js
+++ b/tests/statsCollector.test.js
@@ -1,0 +1,22 @@
+import { StatsCollector } from '../src/sim/StatsCollector.js';
+
+describe('StatsCollector', () => {
+  test('tracks current plant biomass without cumulative growth', () => {
+    const zone = {
+      id: 'z1',
+      plants: [
+        { state: { biomassPartition: { buds_g: 5 }, biomassFresh_g: 10 } }
+      ],
+      deathStats: {}
+    };
+    const sc = new StatsCollector([zone]);
+    // first record
+    sc.recordZone(zone);
+    expect(sc.totalBuds_g).toBeCloseTo(5);
+    expect(sc.totalBiomass_g).toBeCloseTo(10);
+    // second record with same plant weights
+    sc.recordZone(zone);
+    expect(sc.totalBuds_g).toBeCloseTo(5);
+    expect(sc.totalBiomass_g).toBeCloseTo(10);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent StatsCollector from accumulating biomass across ticks
- add unit test to ensure bud/biomass totals reflect current state

## Testing
- `npm test`
- `LOG_LEVEL=error node - <<'NODE' ... (simulation using default savegame)`

------
https://chatgpt.com/codex/tasks/task_e_68a3ec0624ec8325b20941f283783980