### PR TITLE
feat: add configurable simulation duration

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -6,7 +6,8 @@
 export const env = {
   time: {
     // Global default tick length in hours (can be overridden per simulation/zone)
-    tickLengthInHoursDefault: 1
+    tickLengthInHoursDefault: 1,
+    simDaysDefault: 200
   },
   physics: {
     // Air (at approx. 20–25°C)
@@ -80,6 +81,7 @@ export const HOUR_TO_SEC = env.factors.hourToSec;
 export const OUTDOOR_TEMP_C = env.defaults.outsideTemperatureC;
 export const THERMAL_MASS_MULTIPLIER = env.defaults.thermalMassMultiplier;
 export const PASSIVE_UA_PER_M2 = env.defaults.passiveUaPerM2;
+export const SIM_DAYS_DEFAULT = env.time.simDaysDefault;
 
 /**
  * Approximate saturation humidity (water vapor density) for a given temperature.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { createActor } from 'xstate';
 import { initializeSimulation } from './sim/simulation.js';
 import { resolveTickHours } from './lib/time.js';
 import { createRng } from './lib/rng.js';
+import { SIM_DAYS_DEFAULT } from './config/env.js';
 
 // --- Main -------------------------------------------------------------------
 /**
@@ -21,8 +22,9 @@ async function main() {
   // Simulation duration derived from tick length
   const tickLengthInHours = resolveTickHours(zones[0]);
   const ticksPerDay = Math.round(24 / tickLengthInHours);
-  const simDays = Number(process.env.SIM_DAYS) || 730;
-  const durationTicks = simDays * ticksPerDay;
+  const envSimDays = Number(process.env.SIM_DAYS);
+  const simDays = Number.isNaN(envSimDays) ? SIM_DAYS_DEFAULT : envSimDays;
+  const durationTicks = simDays === -1 ? Infinity : simDays * ticksPerDay;
 
   logger.info(`--- STARTING SIMULATION (1 tick = ${tickLengthInHours}h, 1 day = ${ticksPerDay} ticks) ---`);
 


### PR DESCRIPTION
## Summary
- default to 200 simulation days via `SIM_DAYS_DEFAULT`
- allow SIM_DAYS=-1 to run indefinitely

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49d1c6264832587c8ae94a7747dca