### PR TITLE
Limit tick logging to daily summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ npm run dev
 // src/server/index.js
 [src/server/index.js](src/server/index.js)
 
+### Logging
+
+The default log level is conservative (`warn`) to keep the console output tidy.
+When you need more insight for debugging, raise the verbosity by setting
+`LOG_LEVEL`:
+
+```sh
+LOG_LEVEL=debug npm run dev
+```
+
 ### Plant Detail View
 
 The frontend includes a plant detail view reachable via the structure tree. Navigate to a zone, open its plant list and select a plant to inspect. The view compares current environmental readings with the strain's preferred ranges, highlights stress factors across plants in the zone and lists all plants for quick navigation.

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -8,10 +8,13 @@ const isDev = process.env.NODE_ENV !== 'production';
 
 /**
  * Preconfigured Pino logger instance.
+ * Uses a conservative log level by default to avoid noisy output.
+ * Set the `LOG_LEVEL` environment variable (e.g. `LOG_LEVEL=debug`)
+ * when you need more verbose debugging information.
  * @type {import('pino').Logger}
  */
 export const logger = pino({
-  level: process.env.LOG_LEVEL ?? (isDev ? 'debug' : 'info'),
+  level: process.env.LOG_LEVEL ?? (isDev ? 'info' : 'warn'),
   transport: isDev ? { target: 'pino-pretty', options: { colorize: true } } : undefined
 });
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -211,7 +211,7 @@ function _broadcastStatusUpdate() {
   const absoluteTick = simulationState.tickCounter;
   const representativeZone = allZones[0];
   const tickLengthInHours = representativeZone.tickLengthInHours;
-  const ticksPerDay = 24 / tickLengthInHours;
+  const ticksPerDay = Math.round(24 / tickLengthInHours);
 
   // store history and compute aggregates
   tickHistory.push(tickTotals);
@@ -287,7 +287,13 @@ function _broadcastStatusUpdate() {
     grandTotals: costEngine.getGrandTotals()
   };
 
-  logger.info({ tick: absoluteTick, zones: zoneSummaries.length }, 'Broadcasting update to clients');
+  if (absoluteTick % ticksPerDay === 0) {
+    logger.info({
+      day: Math.floor(absoluteTick / ticksPerDay) + 1,
+      balance: costEngine.getGrandTotals().finalBalanceEUR ?? 0,
+      zones: zoneSummaries.length
+    }, 'Broadcasting update to clients');
+  }
   wss.clients.forEach(client => {
     if (client.readyState === 1) { // WebSocket.OPEN
       client.send(JSON.stringify(statusUpdate));

--- a/src/sim/tickMachine.js
+++ b/src/sim/tickMachine.js
@@ -97,7 +97,25 @@ export function createTickMachine() {
               } else {
                 emit('sim.tickCompleted', { zoneId: null }, context.tick, 'warn');
               }
-              context.logger?.info?.({ tick: context.tick, zoneId: context.zone.id }, 'tick completed');
+              const ticksPerDay = Math.round(24 / context.tickLengthInHours);
+              if (context.tick % ticksPerDay === 0) {
+                let netEUR = 0;
+                const ce = context.zone?.costEngine;
+                if (ce) {
+                  if (typeof ce.getTotals === 'function') {
+                    netEUR = ce.getTotals().netEUR ?? 0;
+                  } else if (ce.ledger) {
+                    netEUR = ce.ledger.netEUR ?? 0;
+                  }
+                }
+                const plantCount = context.zone?.plants?.length ?? 0;
+                context.logger?.info?.({
+                  tick: context.tick,
+                  zoneId: context.zone?.id,
+                  netEUR,
+                  plantCount
+                }, 'tick completed');
+              }
               return context.tick + 1;
         }
       })


### PR DESCRIPTION
## Summary
- log tick completion only once per simulated day and include basic metrics
- log server broadcasts daily with balance and zone count
- default logger level to warn unless LOG_LEVEL is set and document how to raise it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a56e6990f483259b7ba2bd8c8f228a