### PR TITLE
feat: make Zone runtime resilient and harvest-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Zone.js made runnable; fallback light cycle; partial harvest; env derivations; import resolution; logging; resilience.

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -31,6 +31,7 @@ export const env = {
     humidity: 0.6,                // Start RH (0..1)
     co2ppm: 420,                  // Start CO₂
     moistureKg: 0,                // Start moisture pool (kg H2O)
+    energyPriceEURPerKWh: 0.30,   // Global default electricity price
 
     // Device reliability (Mean Time Between Failures) -> Default, if not in blueprint
     deviceMTBF_hours_default: 8760 // 1 year
@@ -82,6 +83,7 @@ export const OUTDOOR_TEMP_C = env.defaults.outsideTemperatureC;
 export const THERMAL_MASS_MULTIPLIER = env.defaults.thermalMassMultiplier;
 export const PASSIVE_UA_PER_M2 = env.defaults.passiveUaPerM2;
 export const SIM_DAYS_DEFAULT = env.time.simDaysDefault;
+export const ENERGY_PRICE_EUR_PER_KWH = env.defaults.energyPriceEURPerKWh;
 
 /**
  * Approximate saturation humidity (water vapor density) for a given temperature.


### PR DESCRIPTION
## Summary
- overhaul `Zone` logic: fallback light cycles with lamp warnings, partial harvest & replant, device replacement and cost tracking
- derive humidity, CO₂ and heat each tick with clamped values
- add default energy price to env config and changelog entry

## Testing
- `npm test`
- `LOG_LEVEL=info SIM_DAYS=0 node src/index.js > /tmp/sim.log && tail -n 20 /tmp/sim.log`


------
https://chatgpt.com/codex/tasks/task_e_68a5c99516cc8325be196c4af1087629