### PR TITLE
feat: add harvest debug instrumentation and DLI checks

### DIFF
--- a/src/sim/simulation.js
+++ b/src/sim/simulation.js
@@ -210,7 +210,19 @@ export async function initializeSimulation(savegame = 'default', difficulty = 'n
       keepEntries: true, // Ensure ledger entries are kept for per-room calculations
     });
 
-    const globalRuntime = { logger, costEngine, rng, strainPriceMap, devicePriceMap, blueprints, difficulty: difficultyModifiers };
+    // world-level aggregates (e.g. total harvested buds)
+    const world = { totalBuds_g: 0, strainStats: new Map() };
+
+    const globalRuntime = {
+        logger,
+        costEngine,
+        rng,
+        strainPriceMap,
+        devicePriceMap,
+        blueprints,
+        difficulty: difficultyModifiers,
+        world,
+    };
 
     // --- Build World Hierarchy ---
     const structure = createStructure(structureConfig, globalRuntime);
@@ -270,5 +282,6 @@ export async function initializeSimulation(savegame = 'default', difficulty = 'n
         blueprints,
         statsCollector,
         tickLengthInHours,
+        world,
     };
 }

--- a/src/sim/tickMachine.js
+++ b/src/sim/tickMachine.js
@@ -115,6 +115,7 @@ export function createTickMachine() {
                   netEUR,
                   plantCount
                 }, 'tick completed');
+                context.zone?.debugDailyLog?.(context.tick / ticksPerDay);
               }
               return context.tick + 1;
         }


### PR DESCRIPTION
## Summary
- instrument zone and plant debug logs gated by `DEBUG_HARVEST`
- add DLI calculations, consistency assertions and stress multipliers
- track harvested bud mass per zone and globally with reports

## Testing
- `npm test`
- `DEBUG_HARVEST=1 SIM_DAYS=200 node src/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68aae59ce0d48325ae02de07e4dd4813