### PR TITLE
feat: add deterministic 200‑day simulation harness with instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ data/generated/
 data/cache/
 data/strains/backup/
 docs/__ki-data/
+reports/

--- a/docs/sim_check_200d.md
+++ b/docs/sim_check_200d.md
@@ -1,0 +1,31 @@
+# 200-Day Simulation Check
+
+Run a reproducible 200-day simulation (4800 ticks) and collect basic reports.
+
+## Run
+
+```bash
+npm run sim:200d:report
+```
+
+Optional environment variables:
+- `SIM_DAYS` – number of days to simulate (default `200`).
+- `WB_SEED` – RNG seed (default `codex-checkup-001`).
+- `AUTO_REPLANT` – `true`/`false` (default `true`).
+
+## Outputs
+
+Reports are written to `reports/`:
+
+- `sim_200d_log.csv` – chronological event log
+- `sim_200d_daily.jsonl` – one JSON line per zone and day
+- `sim_200d_summary.json` – aggregated statistics
+- `sim_200d_summary.md` – summary as Markdown tables
+
+Key metrics:
+
+- `global.totalBuds_g` – total harvested buds (must be > 0)
+- `harvestEvents` – number of harvests per zone
+- `global.replantEventsTotal` – total replants (with `AUTO_REPLANT=true`)
+
+The RNG is deterministic when `WB_SEED` is set.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,10 @@ const config = {
   verbose: true,
   testEnvironment: 'node',
   transform: {}, // Needed for ES Modules
-  moduleFileExtensions: ['js', 'json', 'node'],
+  moduleFileExtensions: ['js', 'mjs', 'json', 'node'],
   testMatch: [
-    '**/tests/**/*.test.js'
+    '**/tests/**/*.test.js',
+    '**/tests/**/*.test.mjs'
   ],
   "transformIgnorePatterns": [
     "/node_modules/"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "start": "node src/server/index.js",
     "dev": "node --watch src/server/index.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "sim": "node src/index.js"
+    "sim": "node src/index.js",
+    "sim:200d": "node tools/sim-check/run_200d.mjs",
+    "sim:200d:seed": "WB_SEED=codex-checkup-001 node tools/sim-check/run_200d.mjs",
+    "sim:200d:report": "SIM_DAYS=200 WB_SEED=codex-checkup-001 AUTO_REPLANT=true node tools/sim-check/run_200d.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/src/instrumentation/attach.js
+++ b/src/instrumentation/attach.js
@@ -1,0 +1,119 @@
+import { emit } from './eventBus.js';
+
+/**
+ * Attach instrumentation hooks to Plant and Zone classes.
+ * @param {{Plant: any, Zone: any}} classes
+ */
+export function attach({ Plant, Zone }) {
+  if (Plant && !Plant.prototype.__instrumented) {
+    const origTick = Plant.prototype.tick;
+    Plant.prototype.tick = async function(zone, tickLengthInHours, tickIndex) {
+      const prevStage = this.stage;
+      await origTick.call(this, zone, tickLengthInHours, tickIndex);
+      if (this.stage !== prevStage) {
+        const t = zone?.tickLengthInHours || tickLengthInHours || 1;
+        const ticksPerDay = Math.round(24 / t);
+        emit('phase-change', {
+          plantId: this.id,
+          zoneId: zone?.id,
+          from: prevStage,
+          to: this.stage,
+          tick: tickIndex,
+          day: Math.floor(tickIndex / ticksPerDay)
+        });
+      }
+    };
+    Plant.prototype.__instrumented = true;
+  }
+
+  if (Zone && !Zone.prototype.__instrumented) {
+    const origUpdatePlants = Zone.prototype.updatePlants;
+    Zone.prototype.updatePlants = async function(tickLengthInHours, tickIndex) {
+      const before = new Map(this.plants.map(p => [p.id, p]));
+      await origUpdatePlants.call(this, tickLengthInHours, tickIndex);
+      const after = new Set(this.plants.map(p => p.id));
+      const t = this.tickLengthInHours || tickLengthInHours || 1;
+      const ticksPerDay = Math.round(24 / t);
+      const day = Math.floor(tickIndex / ticksPerDay);
+      for (const [id, p] of before.entries()) {
+        if (!after.has(id)) {
+          emit('death', {
+            plantId: id,
+            zoneId: this.id,
+            reason: p.causeOfDeath || 'unknown',
+            tick: tickIndex,
+            day,
+            strain: p.strain,
+            method: p.method
+          });
+        }
+      }
+    };
+
+    const origHarvestAndInventory = Zone.prototype.harvestAndInventory;
+    Zone.prototype.harvestAndInventory = function(tickIndex) {
+      const before = new Map(this.plants.map(p => [p.id, p]));
+      origHarvestAndInventory.call(this, tickIndex);
+      const after = new Map(this.plants.map(p => [p.id, p]));
+      const t = this.tickLengthInHours || 1;
+      const ticksPerDay = Math.round(24 / t);
+      const day = Math.floor(tickIndex / ticksPerDay);
+      for (const [id, p] of before.entries()) {
+        if (!after.has(id)) {
+          const buds = p.state?.biomassPartition?.buds_g ?? 0;
+          emit('harvest', {
+            plantId: id,
+            zoneId: this.id,
+            buds_g: buds,
+            tick: tickIndex,
+            day,
+            strain: p.strain,
+            method: p.method
+          });
+        }
+      }
+      for (const [id, p] of after.entries()) {
+        if (!before.has(id)) {
+          emit('replant', {
+            zoneId: this.id,
+            newPlantId: id,
+            tick: tickIndex,
+            day,
+            strain: p.strain,
+            method: p.method
+          });
+        }
+      }
+    };
+
+    const origDebugDailyLog = Zone.prototype.debugDailyLog;
+    Zone.prototype.debugDailyLog = function(day) {
+      const totalBiomass = this.plants.reduce((s, p) => s + (p.state?.biomassFresh_g ?? 0), 0);
+      const totalBuds = this.plants.reduce((s, p) => s + (p.state?.biomassPartition?.buds_g ?? 0), 0);
+      const plantsTotal = this.plants.length;
+      const harvestedPlants = this.harvestedPlants;
+      const deadPlants = Object.values(this.deathStats ?? {}).reduce((a, b) => a + b, 0);
+      const lightH = this._debugDay?.lightHours || 0;
+      const avgPPFD = lightH > 0 ? this._debugDay.ppfdSum / lightH : undefined;
+      const avgDLI = avgPPFD != null ? (avgPPFD * 3600 * lightH) / 1e6 : undefined;
+      const totalH = this._debugDay?.totalHours || 0;
+      const meanTemp = totalH > 0 ? this._debugDay.tempSum / totalH : undefined;
+      emit('zone-daily', {
+        zoneId: this.id,
+        day,
+        totalBiomass_g: totalBiomass,
+        totalBuds_g: totalBuds,
+        plantsTotal,
+        harvestedPlants,
+        deadPlants,
+        avgPPFD_umol_m2s: avgPPFD,
+        avgDLI_mol_m2d: avgDLI,
+        meanTemp_C: meanTemp
+      });
+      return origDebugDailyLog ? origDebugDailyLog.call(this, day) : undefined;
+    };
+
+    Zone.prototype.__instrumented = true;
+  }
+}
+

--- a/src/instrumentation/eventBus.js
+++ b/src/instrumentation/eventBus.js
@@ -1,0 +1,17 @@
+import { EventEmitter } from 'events';
+
+// Simple EventEmitter-based bus for instrumentation events
+export const bus = new EventEmitter();
+
+export function emit(event, payload) {
+  bus.emit(event, payload);
+}
+
+export function on(event, handler) {
+  bus.on(event, handler);
+}
+
+export function off(event, handler) {
+  bus.off(event, handler);
+}
+

--- a/src/lib/rng.js
+++ b/src/lib/rng.js
@@ -6,10 +6,10 @@ import seedrandom from 'seedrandom';
 
 /**
  * Create a deterministic random number generator.
- * @param {string} [seed='weed-breed'] - Seed value.
+ * @param {string} [seed=process.env.WB_SEED||'weed-breed'] - Seed value.
  * @returns {{float: function(): number, int: function(number, number): number, pick: function(Array): any}} RNG helpers.
  */
-export function createRng(seed = 'weed-breed') {
+export function createRng(seed = process.env.WB_SEED || 'weed-breed') {
   const rng = seedrandom(seed);
   return {
     float: () => rng(),               // 0..1

--- a/tests/sim_200d.smoke.test.mjs
+++ b/tests/sim_200d.smoke.test.mjs
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const summaryPath = path.resolve(__dirname, '../reports/sim_200d_summary.json');
+
+const summaryExists = fs.existsSync(summaryPath);
+
+const run = summaryExists ? test : test.skip;
+
+run('200d simulation summary sanity', () => {
+  const data = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
+  expect(data.global.totalBuds_g).toBeGreaterThan(0);
+  const hasHarvest = (data.zones || []).some(z => (z.harvestEvents || 0) >= 1);
+  expect(hasHarvest).toBe(true);
+  if (data.global.replantEventsTotal != null) {
+    expect(data.global.replantEventsTotal).toBeGreaterThan(0);
+  }
+});
+
+if (!summaryExists) {
+  test.skip('missing summary – run `npm run sim:200d:report` to generate', () => {});
+}
+
+jest.setTimeout(5000);

--- a/tools/sim-check/reporters.mjs
+++ b/tools/sim-check/reporters.mjs
@@ -1,0 +1,73 @@
+import fs from 'fs';
+
+function avg(arr) {
+  const vals = arr.filter(v => Number.isFinite(v));
+  return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
+}
+
+function buildTable(rows, cols) {
+  const header = '|' + cols.join('|') + '|\n|' + cols.map(() => '---').join('|') + '|\n';
+  const body = rows
+    .map(r => '|' + cols.map(c => (r[c] ?? '')).join('|') + '|\n')
+    .join('');
+  return header + body;
+}
+
+/**
+ * Build summary reports and write to disk.
+ * @param {{zones:Array,world:object,events:Array,dailyEvents:Array}} data
+ * @returns {object} summary object
+ */
+export function buildReports({ zones, world, events, dailyEvents }) {
+  const zoneReport = zones.map(z => {
+    const daily = dailyEvents.filter(d => d.zoneId === z.id);
+    const avgPPFD = avg(daily.map(d => d.avgPPFD_umol_m2s));
+    const avgDLI = avg(daily.map(d => d.avgDLI_mol_m2d));
+    const meanTemp = avg(daily.map(d => d.meanTemp_C));
+    const maxTemp = Math.max(0, ...daily.map(d => d.meanTemp_C || 0));
+    const totalBiomass = daily.length ? daily[daily.length - 1].totalBiomass_g : z.plants.reduce((s, p) => s + (p.state?.biomassFresh_g ?? 0), 0);
+    return {
+      zoneName: z.id,
+      totalBiomass_g: totalBiomass,
+      totalBuds_g: z.totalBuds_g,
+      plantsTotal: z.plants.length,
+      harvestedPlants: z.harvestedPlants,
+      deadPlants: Object.values(z.deathStats ?? {}).reduce((a, b) => a + b, 0),
+      startDayFlower: z.startDayFlower,
+      harvestEvents: z.harvestEvents,
+      firstHarvestDay: z.firstHarvestDay,
+      lastHarvestDay: z.lastHarvestDay,
+      avgDLI_mol_m2d: avgDLI,
+      avgPPFD_umol_m2s: avgPPFD,
+      meanTempFlower_C: meanTemp,
+      maxTemp_C: maxTemp
+    };
+  });
+
+  const strainSummary = Array.from(world.strainStats.entries()).map(([id, s]) => ({
+    strainName: `${s.name} (${id})`,
+    plantsTotal: s.plantsTotal,
+    harvestedPlants: s.harvestedPlants,
+    totalBuds_g: s.totalBuds_g,
+    avgYieldPerPlant_g: s.harvestedPlants ? s.totalBuds_g / s.harvestedPlants : 0,
+    avgFlowerDuration_days: s.harvestedPlants ? s.totalFlowerDurationDays / s.harvestedPlants : 0,
+  }));
+
+  const replantEventsTotal = events.filter(e => e.type === 'replant').length;
+  const global = {
+    totalBuds_g: zoneReport.reduce((a, z) => a + (z.totalBuds_g || 0), 0),
+    replantEventsTotal
+  };
+
+  const summary = { global, zones: zoneReport, strains: strainSummary };
+  fs.writeFileSync('reports/sim_200d_summary.json', JSON.stringify(summary, null, 2));
+
+  let md = '# 200d Simulation Summary\n\n## Zone Report\n\n';
+  md += buildTable(zoneReport, ['zoneName','totalBiomass_g','totalBuds_g','plantsTotal','harvestedPlants','deadPlants','startDayFlower','harvestEvents','firstHarvestDay','lastHarvestDay','avgDLI_mol_m2d','avgPPFD_umol_m2s','meanTempFlower_C','maxTemp_C']);
+  md += '\n## Strain Summary\n\n';
+  md += buildTable(strainSummary, ['strainName','plantsTotal','harvestedPlants','totalBuds_g','avgYieldPerPlant_g','avgFlowerDuration_days']);
+  fs.writeFileSync('reports/sim_200d_summary.md', md);
+
+  return summary;
+}
+

--- a/tools/sim-check/run_200d.mjs
+++ b/tools/sim-check/run_200d.mjs
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import { createActor } from 'xstate';
+import { initializeSimulation } from '../../src/sim/simulation.js';
+import { Plant } from '../../src/engine/Plant.js';
+import { Zone } from '../../src/engine/Zone.js';
+import { attach } from '../../src/instrumentation/attach.js';
+import { bus, emit, on } from '../../src/instrumentation/eventBus.js';
+import { buildReports } from './reporters.mjs';
+
+const SIM_DAYS = Number(process.env.SIM_DAYS || 200);
+const AUTO_REPLANT = (process.env.AUTO_REPLANT ?? 'true') !== 'false';
+const WB_SEED = process.env.WB_SEED || 'codex-checkup-001';
+process.env.WB_SEED = WB_SEED;
+
+attach({ Plant, Zone });
+
+const { structure, costEngine, tickMachineLogic, tickLengthInHours, world } = await initializeSimulation('default');
+
+const zones = structure.rooms.flatMap(r => r.zones);
+const ticksPerDay = Math.round(24 / tickLengthInHours);
+const totalTicks = SIM_DAYS * ticksPerDay;
+
+fs.mkdirSync('reports', { recursive: true });
+const logStream = fs.createWriteStream('reports/sim_200d_log.csv');
+logStream.write('event,tick,day,plantId,zoneId,buds_g,reason,newPlantId,previousPlantId,from,to\n');
+const dailyStream = fs.createWriteStream('reports/sim_200d_daily.jsonl');
+
+const events = [];
+const dailyEvents = [];
+
+on('phase-change', e => {
+  events.push({ type: 'phase-change', ...e });
+  logStream.write([
+    'phase-change',
+    e.tick,
+    e.day,
+    e.plantId,
+    e.zoneId || '',
+    '',
+    '',
+    '',
+    '',
+    e.from,
+    e.to
+  ].join(',') + '\n');
+});
+
+on('harvest', e => {
+  events.push({ type: 'harvest', ...e });
+  logStream.write([
+    'harvest',
+    e.tick,
+    e.day,
+    e.plantId,
+    e.zoneId,
+    e.buds_g || 0,
+    '',
+    '',
+    '',
+    '',
+    ''
+  ].join(',') + '\n');
+});
+
+on('death', e => {
+  events.push({ type: 'death', ...e });
+  logStream.write([
+    'death',
+    e.tick,
+    e.day,
+    e.plantId,
+    e.zoneId,
+    '',
+    e.reason || '',
+    '',
+    '',
+    '',
+    ''
+  ].join(',') + '\n');
+  if (AUTO_REPLANT) {
+    const zone = zones.find(z => z.id === e.zoneId);
+    if (zone) {
+      const newPlant = new Plant({ strain: e.strain, method: e.method, rng: zone.rng });
+      zone.addPlant(newPlant);
+      emit('replant', { zoneId: zone.id, newPlantId: newPlant.id, previousPlantId: e.plantId, tick: e.tick, day: e.day });
+    }
+  }
+});
+
+on('replant', e => {
+  events.push({ type: 'replant', ...e });
+  logStream.write([
+    'replant',
+    e.tick,
+    e.day,
+    '',
+    e.zoneId,
+    '',
+    '',
+    e.newPlantId,
+    e.previousPlantId || '',
+    '',
+    ''
+  ].join(',') + '\n');
+});
+
+on('zone-daily', e => {
+  dailyEvents.push(e);
+  events.push({ type: 'zone-daily', ...e });
+  dailyStream.write(JSON.stringify(e) + '\n');
+});
+
+for (let tick = 1; tick <= totalTicks; tick++) {
+  const absoluteTick = (costEngine._tickCounter || 0) + 1;
+  costEngine.startTick(absoluteTick);
+  for (const zone of zones) {
+    const actor = createActor(tickMachineLogic, {
+      input: { zone, tick: absoluteTick, tickLengthInHours: zone.tickLengthInHours, logger: console }
+    });
+    await new Promise(resolve => {
+      actor.subscribe(state => { if (state.status === 'done') resolve(); });
+      actor.start();
+    });
+  }
+  costEngine.commitTick();
+}
+
+logStream.end();
+dailyStream.end();
+
+const summary = buildReports({ zones, world, events, dailyEvents });
+console.log('Simulation complete. Summary saved to reports/.');
+


### PR DESCRIPTION
## Summary
- add lightweight event bus and hooks to instrument phase changes, harvests, deaths and daily zone metrics
- provide fast-forward 200‑day simulation tool with optional auto-replant and CSV/JSON/Markdown reporting
- document and smoke-test deterministic run artifacts; wire scripts into npm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba88b9de48325b43a4754e97fa5c0