### PR TITLE
fix(daily): snapshot-based daily logs + EOD ordering + reporter + tests

### DIFF
--- a/docs/sim_check_200d.md
+++ b/docs/sim_check_200d.md
@@ -8,7 +8,14 @@ Run a reproducible 200-day simulation (4800 ticks) and collect basic reports.
 npm run sim:200d:report
 ```
 
-Optional environment variables:
+The script uses `cross-env` so environment variables work on Windows and macOS.
+To recompute summaries from existing artifacts:
+
+```bash
+npm run sim:recompute
+```
+
+Optional environment variables for `sim:200d:report`:
 - `SIM_DAYS` – number of days to simulate (default `200`).
 - `WB_SEED` – RNG seed (default `codex-checkup-001`).
 - `AUTO_REPLANT` – `true`/`false` (default `true`).
@@ -18,14 +25,17 @@ Optional environment variables:
 Reports are written to `reports/`:
 
 - `sim_200d_log.csv` – chronological event log
-- `sim_200d_daily.jsonl` – one JSON line per zone and day
+- `sim_200d_daily.jsonl` – one JSON line per zone and day (end-of-day snapshot)
 - `sim_200d_summary.json` – aggregated statistics
-- `sim_200d_summary.md` – summary as Markdown tables
+- `sim_200d_summary.md` – summary as Markdown tables with `day1Biomass_g`
 
 Key metrics:
 
 - `global.totalBuds_g` – total harvested buds (must be > 0)
 - `harvestEvents` – number of harvests per zone
 - `global.replantEventsTotal` – total replants (with `AUTO_REPLANT=true`)
+
+Daily rows are snapshots, so compare `day1Biomass_g` with the final day to verify growth.
+`sim_200d_log.csv` can be inspected to check replant events and other milestones.
 
 The RNG is deterministic when `WB_SEED` is set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       "devDependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "jest": "^30.0.5"
+        "jest": "^30.0.5",
+        "cross-env": "^7.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "sim": "node src/index.js",
     "sim:200d": "node tools/sim-check/run_200d.mjs",
-    "sim:200d:seed": "WB_SEED=codex-checkup-001 node tools/sim-check/run_200d.mjs",
-    "sim:200d:report": "SIM_DAYS=200 WB_SEED=codex-checkup-001 AUTO_REPLANT=true node tools/sim-check/run_200d.mjs"
+    "sim:200d:seed": "cross-env WB_SEED=codex-checkup-001 node tools/sim-check/run_200d.mjs",
+    "sim:200d:report": "cross-env SIM_DAYS=200 WB_SEED=codex-checkup-001 AUTO_REPLANT=true node tools/sim-check/run_200d.mjs",
+    "sim:recompute": "node tools/sim-check/reporters.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -31,7 +32,8 @@
   "devDependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "jest": "^30.0.5"
+    "jest": "^30.0.5",
+    "cross-env": "^7.0.3"
   },
   "packageManager": "npm@^10"
 }

--- a/tests/sim_daily_snapshot.test.mjs
+++ b/tests/sim_daily_snapshot.test.mjs
@@ -1,0 +1,36 @@
+import fs from 'fs';
+
+const dailyFile = 'reports/sim_200d_daily.jsonl';
+const summaryFile = 'reports/sim_200d_summary.json';
+const haveArtifacts = fs.existsSync(dailyFile) && fs.existsSync(summaryFile);
+
+if (!haveArtifacts) {
+  console.warn('sim_daily_snapshot.test skipped: run `npm run sim:200d:report` and `npm run sim:recompute` to generate artifacts.');
+}
+
+(haveArtifacts ? test : test.skip)('daily snapshots are per-day and unique', () => {
+  const lines = fs.readFileSync(dailyFile, 'utf8').trim().split('\n').filter(Boolean);
+  const rows = lines.map(l => JSON.parse(l));
+
+  const pairSet = new Set();
+  const zoneMap = new Map();
+  for (const r of rows) {
+    const key = `${r.zoneId}-${r.day}`;
+    expect(pairSet.has(key)).toBe(false);
+    pairSet.add(key);
+    if (!zoneMap.has(r.zoneId)) zoneMap.set(r.zoneId, []);
+    zoneMap.get(r.zoneId).push(r);
+  }
+
+  const zoneCount = zoneMap.size;
+  const maxDay = Math.max(...rows.map(r => r.day));
+  expect(rows.length).toBe(zoneCount * maxDay);
+
+  for (const [zoneId, arr] of zoneMap) {
+    arr.sort((a, b) => a.day - b.day);
+    const first = arr[0];
+    const last = arr[arr.length - 1];
+    expect(last.totalBiomass_g).toBeGreaterThanOrEqual(first.totalBiomass_g);
+    expect(last.totalBiomass_g).toBeGreaterThan(0);
+  }
+});

--- a/tools/sim-check/reporters.mjs
+++ b/tools/sim-check/reporters.mjs
@@ -1,73 +1,122 @@
 import fs from 'fs';
+import { writeFile } from 'node:fs/promises';
 
+/**
+ * Compute the arithmetic mean of numeric values.
+ * @param {Array<*>} arr
+ * @returns {number|undefined} mean or undefined
+ */
 function avg(arr) {
-  const vals = arr.filter(v => Number.isFinite(v));
-  return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
+  const vals = arr.filter(v => typeof v === 'number' && !Number.isNaN(v));
+  return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : undefined;
 }
 
+/**
+ * Build a Markdown table.
+ * @param {Array<object>} rows
+ * @param {Array<string>} cols
+ * @returns {string}
+ */
 function buildTable(rows, cols) {
   const header = '|' + cols.join('|') + '|\n|' + cols.map(() => '---').join('|') + '|\n';
-  const body = rows
-    .map(r => '|' + cols.map(c => (r[c] ?? '')).join('|') + '|\n')
-    .join('');
+  const body = rows.map(r => '|' + cols.map(c => (r[c] ?? '')).join('|') + '|\n').join('');
   return header + body;
 }
 
 /**
- * Build summary reports and write to disk.
- * @param {{zones:Array,world:object,events:Array,dailyEvents:Array}} data
- * @returns {object} summary object
+ * Parse the events CSV if present.
+ * @param {string} file
+ * @returns {Map<string, Array<{event:string,day:number}>>}
  */
-export function buildReports({ zones, world, events, dailyEvents }) {
-  const zoneReport = zones.map(z => {
-    const daily = dailyEvents.filter(d => d.zoneId === z.id);
-    const avgPPFD = avg(daily.map(d => d.avgPPFD_umol_m2s));
-    const avgDLI = avg(daily.map(d => d.avgDLI_mol_m2d));
-    const meanTemp = avg(daily.map(d => d.meanTemp_C));
-    const maxTemp = Math.max(0, ...daily.map(d => d.meanTemp_C || 0));
-    const totalBiomass = daily.length ? daily[daily.length - 1].totalBiomass_g : z.plants.reduce((s, p) => s + (p.state?.biomassFresh_g ?? 0), 0);
-    return {
-      zoneName: z.id,
-      totalBiomass_g: totalBiomass,
-      totalBuds_g: z.totalBuds_g,
-      plantsTotal: z.plants.length,
-      harvestedPlants: z.harvestedPlants,
-      deadPlants: Object.values(z.deathStats ?? {}).reduce((a, b) => a + b, 0),
-      startDayFlower: z.startDayFlower,
-      harvestEvents: z.harvestEvents,
-      firstHarvestDay: z.firstHarvestDay,
-      lastHarvestDay: z.lastHarvestDay,
-      avgDLI_mol_m2d: avgDLI,
-      avgPPFD_umol_m2s: avgPPFD,
-      meanTempFlower_C: meanTemp,
-      maxTemp_C: maxTemp
-    };
-  });
+function parseEvents(file) {
+  const map = new Map();
+  if (!fs.existsSync(file)) return map;
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n').slice(1);
+  for (const line of lines) {
+    if (!line) continue;
+    const [event, , day, , zoneId] = line.split(',');
+    if (!zoneId) continue;
+    if (!map.has(zoneId)) map.set(zoneId, []);
+    map.get(zoneId).push({ event, day: Number(day) });
+  }
+  return map;
+}
 
-  const strainSummary = Array.from(world.strainStats.entries()).map(([id, s]) => ({
-    strainName: `${s.name} (${id})`,
-    plantsTotal: s.plantsTotal,
-    harvestedPlants: s.harvestedPlants,
-    totalBuds_g: s.totalBuds_g,
-    avgYieldPerPlant_g: s.harvestedPlants ? s.totalBuds_g / s.harvestedPlants : 0,
-    avgFlowerDuration_days: s.harvestedPlants ? s.totalFlowerDurationDays / s.harvestedPlants : 0,
-  }));
+/**
+ * Build summary reports from generated artifacts.
+ * Reads daily snapshots and event logs from the reports directory.
+ * @returns {Promise<object>} summary object
+ */
+export async function buildReports() {
+  const dailyPath = 'reports/sim_200d_daily.jsonl';
+  const logPath = 'reports/sim_200d_log.csv';
 
-  const replantEventsTotal = events.filter(e => e.type === 'replant').length;
+  const dailyLines = fs.existsSync(dailyPath)
+    ? fs.readFileSync(dailyPath, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+
+  const zoneMap = new Map();
+  for (const line of dailyLines) {
+    const row = JSON.parse(line);
+    if (!zoneMap.has(row.zoneId)) zoneMap.set(row.zoneId, []);
+    zoneMap.get(row.zoneId).push(row);
+  }
+
+  const eventsByZone = parseEvents(logPath);
+  const zones = [];
+
+  for (const [zoneId, rows] of zoneMap) {
+    rows.sort((a, b) => a.day - b.day);
+    const first = rows[0];
+    const last = rows[rows.length - 1];
+
+    const env = {};
+    const avgDLI = avg(rows.map(r => r.avgDLI_mol_m2d));
+    if (avgDLI !== undefined) env.avgDLI_mol_m2d = avgDLI;
+    const avgPPFD = avg(rows.map(r => r.avgPPFD_umol_m2s));
+    if (avgPPFD !== undefined) env.avgPPFD_umol_m2s = avgPPFD;
+    const meanTemp = avg(rows.map(r => r.meanTempFlower_C));
+    if (meanTemp !== undefined) env.meanTempFlower_C = meanTemp;
+    const maxTemps = rows.map(r => r.maxTemp_C).filter(v => typeof v === 'number');
+    if (maxTemps.length) env.maxTemp_C = Math.max(...maxTemps);
+
+    const zoneEvents = eventsByZone.get(zoneId) || [];
+    const harvests = zoneEvents.filter(e => e.event === 'harvest');
+    const harvestEvents = harvests.length;
+    const firstHarvestDay = harvestEvents ? Math.min(...harvests.map(h => h.day)) : undefined;
+    const lastHarvestDay = harvestEvents ? Math.max(...harvests.map(h => h.day)) : undefined;
+
+    zones.push({
+      zoneId,
+      zoneName: first.zoneName || zoneId,
+      plantsTotal: last.plantsTotal,
+      day1Biomass_g: first.totalBiomass_g,
+      totalBiomass_g: last.totalBiomass_g,
+      totalBuds_g: last.totalBuds_g,
+      harvestEvents,
+      ...(firstHarvestDay !== undefined ? { firstHarvestDay } : {}),
+      ...(lastHarvestDay !== undefined ? { lastHarvestDay } : {}),
+      ...env
+    });
+  }
+
   const global = {
-    totalBuds_g: zoneReport.reduce((a, z) => a + (z.totalBuds_g || 0), 0),
-    replantEventsTotal
+    totalBuds_g: zones.reduce((a, z) => a + (z.totalBuds_g || 0), 0),
+    replantEventsTotal: Array.from(eventsByZone.values()).reduce((s, ev) => s + ev.filter(e => e.event === 'replant').length, 0)
   };
 
-  const summary = { global, zones: zoneReport, strains: strainSummary };
-  fs.writeFileSync('reports/sim_200d_summary.json', JSON.stringify(summary, null, 2));
+  const summary = { global, zones };
+  await writeFile('reports/sim_200d_summary.json', JSON.stringify(summary, null, 2));
 
+  const zoneCols = ['zoneId', 'zoneName', 'plantsTotal', 'day1Biomass_g', 'totalBiomass_g', 'totalBuds_g', 'harvestEvents', 'firstHarvestDay', 'lastHarvestDay', 'avgDLI_mol_m2d', 'avgPPFD_umol_m2s', 'meanTempFlower_C', 'maxTemp_C'];
+  const usedCols = zoneCols.filter(c => zones.some(z => z[c] !== undefined));
   let md = '# 200d Simulation Summary\n\n## Zone Report\n\n';
-  md += buildTable(zoneReport, ['zoneName','totalBiomass_g','totalBuds_g','plantsTotal','harvestedPlants','deadPlants','startDayFlower','harvestEvents','firstHarvestDay','lastHarvestDay','avgDLI_mol_m2d','avgPPFD_umol_m2s','meanTempFlower_C','maxTemp_C']);
-  md += '\n## Strain Summary\n\n';
-  md += buildTable(strainSummary, ['strainName','plantsTotal','harvestedPlants','totalBuds_g','avgYieldPerPlant_g','avgFlowerDuration_days']);
-  fs.writeFileSync('reports/sim_200d_summary.md', md);
+  md += buildTable(zones, usedCols);
+  await writeFile('reports/sim_200d_summary.md', md);
 
   return summary;
 }
 
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await buildReports();
+}

--- a/tools/sim-check/run_200d.mjs
+++ b/tools/sim-check/run_200d.mjs
@@ -1,10 +1,11 @@
 import fs from 'fs';
+import { appendFile } from 'node:fs/promises';
 import { createActor } from 'xstate';
 import { initializeSimulation } from '../../src/sim/simulation.js';
 import { Plant } from '../../src/engine/Plant.js';
 import { Zone } from '../../src/engine/Zone.js';
 import { attach } from '../../src/instrumentation/attach.js';
-import { bus, emit, on } from '../../src/instrumentation/eventBus.js';
+import { emit, on } from '../../src/instrumentation/eventBus.js';
 import { buildReports } from './reporters.mjs';
 
 const SIM_DAYS = Number(process.env.SIM_DAYS || 200);
@@ -23,13 +24,50 @@ const totalTicks = SIM_DAYS * ticksPerDay;
 fs.mkdirSync('reports', { recursive: true });
 const logStream = fs.createWriteStream('reports/sim_200d_log.csv');
 logStream.write('event,tick,day,plantId,zoneId,buds_g,reason,newPlantId,previousPlantId,from,to\n');
-const dailyStream = fs.createWriteStream('reports/sim_200d_daily.jsonl');
 
-const events = [];
-const dailyEvents = [];
+/** Pending replant requests executed after daily snapshots. */
+const pendingReplants = [];
+
+/**
+ * Append an object as JSON to a line oriented file.
+ * @param {string} file
+ * @param {object} obj
+ */
+async function writeJsonl(file, obj) {
+  await appendFile(file, JSON.stringify(obj) + '\n', 'utf8');
+}
+
+/**
+ * Compute a per-zone end-of-day snapshot. Do not carry over accumulators across days.
+ * @param {Zone} zone
+ * @param {number} day
+ */
+function snapshotZone(zone, day) {
+  const plants = (zone.activePlants ?? zone.plants ?? []).filter(p => !p.isDead);
+  const totalBiomass_g = plants.reduce((a, p) => a + (p.state?.biomassFresh_g ?? 0), 0);
+  const totalBuds_g = plants.reduce((a, p) => a + (p.state?.biomassPartition?.buds_g ?? 0), 0);
+
+  const env = zone.env?.daily ?? {};
+  const flowering = zone.env?.flowering ?? {};
+
+  const row = {
+    zoneId: zone.id,
+    zoneName: zone.name,
+    day,
+    plantsTotal: plants.length,
+    totalBiomass_g,
+    totalBuds_g
+  };
+
+  if (typeof env.dli === 'number') row.avgDLI_mol_m2d = env.dli;
+  if (typeof env.ppfd === 'number') row.avgPPFD_umol_m2s = env.ppfd;
+  if (typeof flowering.meanTemp === 'number') row.meanTempFlower_C = flowering.meanTemp;
+  if (typeof env.maxTemp === 'number') row.maxTemp_C = env.maxTemp;
+
+  return row;
+}
 
 on('phase-change', e => {
-  events.push({ type: 'phase-change', ...e });
   logStream.write([
     'phase-change',
     e.tick,
@@ -46,7 +84,6 @@ on('phase-change', e => {
 });
 
 on('harvest', e => {
-  events.push({ type: 'harvest', ...e });
   logStream.write([
     'harvest',
     e.tick,
@@ -63,7 +100,6 @@ on('harvest', e => {
 });
 
 on('death', e => {
-  events.push({ type: 'death', ...e });
   logStream.write([
     'death',
     e.tick,
@@ -78,17 +114,11 @@ on('death', e => {
     ''
   ].join(',') + '\n');
   if (AUTO_REPLANT) {
-    const zone = zones.find(z => z.id === e.zoneId);
-    if (zone) {
-      const newPlant = new Plant({ strain: e.strain, method: e.method, rng: zone.rng });
-      zone.addPlant(newPlant);
-      emit('replant', { zoneId: zone.id, newPlantId: newPlant.id, previousPlantId: e.plantId, tick: e.tick, day: e.day });
-    }
+    pendingReplants.push({ zoneId: e.zoneId, plantId: e.plantId, strain: e.strain, method: e.method, tick: e.tick, day: e.day });
   }
 });
 
 on('replant', e => {
-  events.push({ type: 'replant', ...e });
   logStream.write([
     'replant',
     e.tick,
@@ -104,12 +134,6 @@ on('replant', e => {
   ].join(',') + '\n');
 });
 
-on('zone-daily', e => {
-  dailyEvents.push(e);
-  events.push({ type: 'zone-daily', ...e });
-  dailyStream.write(JSON.stringify(e) + '\n');
-});
-
 for (let tick = 1; tick <= totalTicks; tick++) {
   const absoluteTick = (costEngine._tickCounter || 0) + 1;
   costEngine.startTick(absoluteTick);
@@ -123,11 +147,27 @@ for (let tick = 1; tick <= totalTicks; tick++) {
     });
   }
   costEngine.commitTick();
+  if (tick % ticksPerDay === 0) {
+    const day = tick / ticksPerDay;
+    for (const zone of zones) {
+      const row = snapshotZone(zone, day);
+      await writeJsonl('reports/sim_200d_daily.jsonl', row);
+    }
+    if (AUTO_REPLANT && pendingReplants.length) {
+      for (const r of pendingReplants.splice(0)) {
+        const zone = zones.find(z => z.id === r.zoneId);
+        if (zone) {
+          const newPlant = new Plant({ strain: r.strain, method: r.method, rng: zone.rng });
+          zone.addPlant(newPlant);
+          emit('replant', { zoneId: zone.id, newPlantId: newPlant.id, previousPlantId: r.plantId, tick: (costEngine._tickCounter || 0), day: day + 1 });
+        }
+      }
+    }
+  }
 }
 
 logStream.end();
-dailyStream.end();
 
-const summary = buildReports({ zones, world, events, dailyEvents });
+await buildReports();
 console.log('Simulation complete. Summary saved to reports/.');
 


### PR DESCRIPTION
## Summary
- log daily per-zone snapshots before replant and append to JSONL
- recompute summary from final snapshots; include day1Biomass and optional env metrics
- add test for snapshot integrity and cross-platform scripts with cross-env

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb1de1dbc8325844662c39d0874b6