### PR TITLE
Add zone update helper for demos

### DIFF
--- a/src/demos/structure_rooms_zones_demo.js
+++ b/src/demos/structure_rooms_zones_demo.js
@@ -30,7 +30,7 @@ for (let i = 0; i < 5; i++) zone.addPlant(new Plant());
 
 for (let tick = 0; tick < totalTicks; tick++) {
   const day = Math.floor(tick / TICKS_PER_DAY) + 1;
-  zone.update({ tick, day, TICKS_PER_DAY });
+  await zone.update({ tick, day, TICKS_PER_DAY });
   if (tick % TICKS_PER_DAY === TICKS_PER_DAY - 1) {
     zone.recomputeMetrics();
     writeDailySnapshot(day, zone, {

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -199,6 +199,26 @@ export class Zone {
 
   // --- Public Methods ----------------------------------------------------
 
+  /**
+   * Convenience wrapper that runs one complete simulation tick.
+   *
+   * This mirrors the sequence used by the tick state machine and exists
+   * primarily for simple demos and legacy callers that previously invoked
+   * `zone.update(...)` directly.
+   *
+   * @param {object} [opts]
+   * @param {number} [opts.tick=0] - Absolute tick index
+   * @returns {Promise<void>} Resolves when the tick has been processed
+   */
+  async update({ tick = 0 } = {}) {
+    this.applyDevices?.(tick);
+    this.deriveEnvironment?.();
+    await this.updatePlants?.(this.tickLengthInHours, tick);
+    this.irrigateAndFeed?.();
+    this.harvestAndInventory?.(tick);
+    this.accounting?.(tick);
+  }
+
   applyDevices(tickIndex) {
     const s = ensureEnv(this);
     resetEnvAggregates(s);


### PR DESCRIPTION
## Summary
- add a convenience `Zone.update` method to perform a full simulation tick
- await the update in the structure/rooms/zones demo to prevent TypeError

## Testing
- `node src/demos/structure_rooms_zones_demo.js --env=production --logLevel=warn --simDays=2`
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae00baa4cc8325bef93874bb8311c9