### PR TITLE
feat: add zone replanting policy

### DIFF
--- a/scripts/audit_last.mjs
+++ b/scripts/audit_last.mjs
@@ -26,6 +26,20 @@ for (const [zoneId, arr] of zoneMap.entries()) {
   const harvestEvents = arr.reduce((m, a) => Math.max(m, a.harvestEvents ?? 0), 0);
   const firstHarvestDay = Math.min(...arr.map(a => a.firstHarvestDay ?? Infinity));
   const lastHarvestDay = Math.max(...arr.map(a => a.lastHarvestDay ?? -Infinity));
+  // BEGIN: REPLANTING v1 (do not remove)
+  const replantsAttempted = arr.reduce((s, a) => s + (a.replantsAttempted ?? 0), 0);
+  const replantsSucceeded = arr.reduce((s, a) => s + (a.replantsSucceeded ?? 0), 0);
+  const replantsSkipped = arr.reduce((s, a) => s + (a.replantsSkipped ?? 0), 0);
+  const finalOccupancy = (lastWithPlants?.plantsTotal ?? 0) / (lastWithPlants?.capacity ?? 1);
+  const seedCostEUR = arr.reduce((s, a) => s + (a.seedCostEUR ?? 0), 0);
+  const substrateCostEUR = arr.reduce((s, a) => s + (a.substrateCostEUR ?? 0), 0);
+  const skips = {
+    zoneNotEmpty: arr.reduce((s, a) => s + (a.skips?.zoneNotEmpty ?? 0), 0),
+    cooldownWindow: arr.reduce((s, a) => s + (a.skips?.cooldownWindow ?? 0), 0),
+    noSeedPrice: arr.reduce((s, a) => s + (a.skips?.noSeedPrice ?? 0), 0),
+    noBudget: arr.reduce((s, a) => s + (a.skips?.noBudget ?? 0), 0),
+  };
+  // END: REPLANTING v1
   summary.push({
     zoneId,
     plantsTotal: day1?.plantsTotal ?? 0,
@@ -34,6 +48,15 @@ for (const [zoneId, arr] of zoneMap.entries()) {
     harvestEvents,
     firstHarvestDay: isFinite(firstHarvestDay) ? firstHarvestDay : null,
     lastHarvestDay: isFinite(lastHarvestDay) ? lastHarvestDay : null,
+    // BEGIN: REPLANTING v1 (do not remove)
+    replantsAttempted,
+    replantsSucceeded,
+    replantsSkipped,
+    finalOccupancy,
+    seedCostEUR,
+    substrateCostEUR,
+    skips,
+    // END: REPLANTING v1
   });
   if (harvestEvents === 0 && (day1?.totalBiomass_g ?? 0) > (lastWithPlants?.totalBiomass_g ?? 0) * 5) {
     console.warn(`Warning: ${zoneId} lost biomass without harvest events`);

--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -10,6 +10,9 @@ import { env } from '../config/env.js';
 import { resolveTickHours } from '../lib/time.js';
 import { v4 as uuidv4 } from 'uuid';
 import { createRng } from '../lib/rng.js';
+// BEGIN: REPLANTING v1 (do not remove)
+import crypto from 'node:crypto';
+// END: REPLANTING v1
 
 /**
  * Simulation model for a single plant.
@@ -633,3 +636,25 @@ function clampVal(v, min, max) {
   return Math.min(max, Math.max(min, v));
 }
 
+// BEGIN: REPLANTING v1 (do not remove)
+/**
+ * Factory for a freshly seeded plant.
+ * Fits into existing Plant lifecycle without changing public API.
+ * @param {string} zoneId
+ * @param {string} strainId
+ * @param {number} slotIndex
+ */
+export function seedPlantFactory(zoneId, strainId, slotIndex) {
+  return new Plant({
+    id: crypto.randomUUID?.() ?? require('node:crypto').randomUUID(),
+    zoneId,
+    strain: { id: strainId },
+    slotIndex,
+    stage: 'seedling',
+    ageHours: 0,
+    area_m2: 2.5,
+    payload: {},
+    alive: true,
+  });
+}
+// END: REPLANTING v1

--- a/src/engine/ReplantingPolicy.js
+++ b/src/engine/ReplantingPolicy.js
@@ -1,0 +1,39 @@
+// BEGIN: REPLANTING v1 (do not remove)
+/**
+ * Replanting policy configuration.
+ * @typedef {Object} ReplantingPolicy
+ * @property {boolean} [enabled=true]
+ * @property {'zoneEmpty'|'perSlot'} [zoneGateMode='zoneEmpty']
+ * @property {number} [zoneEmptyCooldownHours=0]
+ * @property {boolean} [seedAllWhenZoneEmpty=true]
+ * @property {string} [defaultStrainId]
+ * @property {number} [replantDelayInHours=0] Only for 'perSlot' mode
+ * @property {number} [minBudgetEur=0]
+ * @property {number} [maxConcurrentBatches=1] Especially for 'perSlot'
+ * @property {boolean} [requireSubstrateReset=false]
+ */
+
+export const DEFAULT_REPLANTING_POLICY = /** @type {ReplantingPolicy} */ ({
+  enabled: true,
+  zoneGateMode: 'zoneEmpty',
+  zoneEmptyCooldownHours: 0,
+  seedAllWhenZoneEmpty: true,
+  defaultStrainId: undefined,
+  replantDelayInHours: 0,
+  minBudgetEur: 0,
+  maxConcurrentBatches: 1,
+  requireSubstrateReset: false,
+});
+
+/**
+ * Normalize user provided replanting policy.
+ * @param {Partial<ReplantingPolicy>} [input]
+ * @returns {ReplantingPolicy}
+ */
+export function normalizeReplantingPolicy(input = {}) {
+  return {
+    ...DEFAULT_REPLANTING_POLICY,
+    ...(input || {}),
+  };
+}
+// END: REPLANTING v1

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -7,9 +7,13 @@
 import { ensureEnv, resetEnvAggregates, getZoneVolume, clamp } from './deviceUtils.js';
 import { env, AIR_DENSITY, AIR_CP, saturationMoistureKgPerM3 } from '../config/env.js';
 import { resolveTickHours } from '../lib/time.js';
-import { Plant } from './Plant.js';
+import { Plant, seedPlantFactory } from './Plant.js';
 import { createDevice } from './factories/deviceFactory.js';
 import { writeHarvestEvent } from '../lib/reporting/reportWriters.js';
+// BEGIN: REPLANTING v1 (do not remove)
+import { emit } from '../runtime/eventBus.js';
+import { normalizeReplantingPolicy } from './ReplantingPolicy.js';
+// END: REPLANTING v1
 
 // Helper to read from Map or plain object
 const get = (m, k) => m?.get?.(k) ?? m?.[k];
@@ -24,6 +28,7 @@ export class Zone {
     runtime = {},
     roomId = null,
     structureId = null,
+    policy = {},
   } = {}) {
     this.id = id;
     this.name = name;
@@ -41,6 +46,11 @@ export class Zone {
     this.strainPriceMap = runtime.strainPriceMap;
     this.devicePriceMap = runtime.devicePriceMap;
     this.blueprints = runtime.blueprints;
+    // BEGIN: REPLANTING v1 (do not remove)
+    this.replantingPolicy = normalizeReplantingPolicy(policy?.replanting);
+    this.capacity = Math.max(0, Math.floor(this.area / 2.5));
+    this.emptySinceTick = null;
+    // END: REPLANTING v1
 
     this.devices = [];
     this.plants = [];
@@ -216,6 +226,9 @@ export class Zone {
     await this.updatePlants?.(this.tickLengthInHours, tick);
     this.irrigateAndFeed?.();
     this.harvestAndInventory?.(tick);
+    // BEGIN: REPLANTING v1 (do not remove)
+    this.replanting?.({ tick });
+    // END: REPLANTING v1
     this.accounting?.(tick);
   }
 
@@ -308,6 +321,49 @@ export class Zone {
     this.#replaceBrokenDevices();
   }
 
+  // BEGIN: REPLANTING v1 (do not remove)
+  /**
+   * Replant zone when completely empty and cooldown passed.
+   * @param {{tick?:number}} [ctx]
+   */
+  replanting({ tick = 0 } = {}) {
+    const policy = this.replantingPolicy;
+    if (!policy?.enabled || policy.zoneGateMode !== 'zoneEmpty') return;
+    if (this.plants.length > 0) {
+      emit('zone.replant.skipped', { zoneId: this.id, reason: 'zoneNotEmpty' }, tick);
+      emit('zone.replant.attempted', { zoneId: this.id, tick, attempted: 0, succeeded: 0, skipped: this.capacity, gateMode: policy.zoneGateMode }, tick);
+      return;
+    }
+    const ticksPerHour = 1 / this.tickLengthInHours;
+    if (policy.zoneEmptyCooldownHours > 0) {
+      const needed = policy.zoneEmptyCooldownHours * ticksPerHour;
+      if (this.emptySinceTick == null || (tick - this.emptySinceTick) < needed) {
+        emit('zone.replant.skipped', { zoneId: this.id, reason: 'cooldownWindow' }, tick);
+        emit('zone.replant.attempted', { zoneId: this.id, tick, attempted: 0, succeeded: 0, skipped: this.capacity, gateMode: policy.zoneGateMode }, tick);
+        return;
+      }
+    }
+    const strainId = policy.defaultStrainId ?? this.plantTemplate?.strain?.id;
+    if (!strainId) {
+      emit('zone.replant.skipped', { zoneId: this.id, reason: 'noStrain' }, tick);
+      emit('zone.replant.attempted', { zoneId: this.id, tick, attempted: 0, succeeded: 0, skipped: this.capacity, gateMode: policy.zoneGateMode }, tick);
+      return;
+    }
+    let succeeded = 0;
+    for (let i = 0; i < this.capacity; i++) {
+      const plant = seedPlantFactory(this.id, strainId, i);
+      this.addPlant(plant);
+      const priceInfo = get(this.strainPriceMap, strainId) ?? {};
+      const seedPriceEur = Number(priceInfo.seedPrice ?? 0);
+      const substrateCostEur = policy.requireSubstrateReset ? Number(priceInfo.substrateCostEUR ?? 0) : 0;
+      emit('plant.seeded', { zoneId: this.id, plantId: plant.id, slotIndex: i, strainId, tick, seedPriceEur, substrateCostEur }, tick);
+      succeeded++;
+    }
+    emit('zone.replant.attempted', { zoneId: this.id, tick, attempted: this.capacity, succeeded, skipped: this.capacity - succeeded, gateMode: policy.zoneGateMode }, tick);
+    this.emptySinceTick = null;
+  }
+  // END: REPLANTING v1
+
   accounting(tickIndex) {
     this.#bookDeviceCosts(tickIndex);
   }
@@ -399,10 +455,17 @@ export class Zone {
         survivors.push(p);
       }
     }
-    const removed = this.plants.length - survivors.length;
-    this.plants = survivors;
-    if (removed > 0) this.#log('info', { removed }, 'Removed dead plants');
-    this.recomputeMetrics();
+      const removed = this.plants.length - survivors.length;
+      this.plants = survivors;
+      if (removed > 0) this.#log('info', { removed }, 'Removed dead plants');
+      // BEGIN: REPLANTING v1 (do not remove)
+      if (this.plants.length === 0) {
+        this.emptySinceTick ??= tickIndex;
+      } else {
+        this.emptySinceTick = null;
+      }
+      // END: REPLANTING v1
+      this.recomputeMetrics();
   }
 
   // -----------------------------------------------------------------------
@@ -449,33 +512,40 @@ export class Zone {
       }
     }
 
-    // remove harvested
-    this.plants = keep;
-    const harvested = ready.length;
-    if (harvested > 0) {
-      this.harvestEvents += harvested;
-      const dayIdx = Math.floor(tickIndex / ticksPerDay);
-      if (this.firstHarvestDay == null) this.firstHarvestDay = dayIdx;
-      this.lastHarvestDay = dayIdx;
-      if (process.env.DEBUG_HARVEST && this.harvestedPlants > 0) {
-        console.assert(this.totalBuds_g >= this.harvestedPlants * 0.1, 'totalBuds_g too low');
+      // remove harvested
+      this.plants = keep;
+      const harvested = ready.length;
+      if (harvested > 0) {
+        this.harvestEvents += harvested;
+        const dayIdx = Math.floor(tickIndex / ticksPerDay);
+        if (this.firstHarvestDay == null) this.firstHarvestDay = dayIdx;
+        this.lastHarvestDay = dayIdx;
+        if (process.env.DEBUG_HARVEST && this.harvestedPlants > 0) {
+          console.assert(this.totalBuds_g >= this.harvestedPlants * 0.1, 'totalBuds_g too low');
+        }
       }
-    }
-
-    // determine template
-    const template = this.plantTemplate || ready[0] || keep[0];
-    if (template) {
-      let areaPerPlant = template.method?.areaPerPlant;
-      if (!areaPerPlant || areaPerPlant <= 0) areaPerPlant = template.area_m2;
-      if (!areaPerPlant || areaPerPlant < 1) areaPerPlant = 2.5; // sensible default
-      const capacity = Math.max(0, Math.floor(this.area / areaPerPlant));
-      const need = Math.max(0, capacity - this.plants.length);
-      for (let i = 0; i < need; i++) {
-        const newPlant = new Plant({ strain: template.strain, method: template.method, rng: this.rng, area_m2: areaPerPlant });
-        this.addPlant(newPlant);
+      // BEGIN: REPLANTING v1 (do not remove)
+      if (this.plants.length === 0) {
+        this.emptySinceTick ??= tickIndex;
+      } else {
+        this.emptySinceTick = null;
       }
-      this.#log('info', { harvested, revenueEUR, replanted: need }, 'HARVEST_ZONE_TICK');
-    }
+      if (this.replantingPolicy?.zoneGateMode === 'perSlot') {
+        const template = this.plantTemplate || ready[0] || keep[0];
+        if (template) {
+          let areaPerPlant = template.method?.areaPerPlant;
+          if (!areaPerPlant || areaPerPlant <= 0) areaPerPlant = template.area_m2;
+          if (!areaPerPlant || areaPerPlant < 1) areaPerPlant = 2.5; // sensible default
+          const capacity = Math.max(0, Math.floor(this.area / areaPerPlant));
+          const need = Math.max(0, capacity - this.plants.length);
+          for (let i = 0; i < need; i++) {
+            const newPlant = new Plant({ strain: template.strain, method: template.method, rng: this.rng, area_m2: areaPerPlant });
+            this.addPlant(newPlant);
+          }
+          this.#log('info', { harvested, revenueEUR, replanted: need }, 'HARVEST_ZONE_TICK');
+        }
+      }
+      // END: REPLANTING v1
   }
 
   #replaceBrokenDevices() {

--- a/src/runtime/tickMachine.js
+++ b/src/runtime/tickMachine.js
@@ -77,6 +77,9 @@ export function createTickMachine() {
           return;
         }
         context.zone.harvestAndInventory?.(context.tick);
+        // BEGIN: REPLANTING v1 (do not remove)
+        context.zone.replanting?.({ tick: context.tick });
+        // END: REPLANTING v1
       },
       onAccounting: ({ context }) => {
         if (!context.zone) {

--- a/tests/replanting.policy.test.js
+++ b/tests/replanting.policy.test.js
@@ -1,0 +1,33 @@
+import { Zone } from '../src/engine/Zone.js';
+import { Plant } from '../src/engine/Plant.js';
+import { CostEngine } from '../src/engine/CostEngine.js';
+import { events$ } from '../src/runtime/eventBus.js';
+
+describe('Replanting policy', () => {
+  test('skips when zone not empty', () => {
+    const costEngine = new CostEngine({ keepEntries: true });
+    const zone = new Zone({ id: 'z1', runtime: { costEngine } });
+    zone.addPlant(new Plant({ strain: { id: 's1' } }));
+    const events = [];
+    const sub = events$.subscribe(e => events.push(e));
+    zone.replanting({ tick: 0 });
+    sub.unsubscribe();
+    const skip = events.find(e => e.type === 'zone.replant.skipped');
+    expect(skip).toBeTruthy();
+    expect(skip.payload.reason).toBe('zoneNotEmpty');
+  });
+
+  test('respects cooldown', () => {
+    const strainId = 's1';
+    const costEngine = new CostEngine({ strainPriceMap: new Map([[strainId, { seedPrice: 1 }]]), keepEntries: true });
+    const zone = new Zone({ id: 'z2', runtime: { costEngine }, policy: { replanting: { zoneEmptyCooldownHours: 2, defaultStrainId: strainId } } });
+    zone.emptySinceTick = 0;
+    const events = [];
+    const sub = events$.subscribe(e => events.push(e));
+    zone.replanting({ tick: 1 });
+    sub.unsubscribe();
+    const skip = events.find(e => e.type === 'zone.replant.skipped');
+    expect(skip).toBeTruthy();
+    expect(skip.payload.reason).toBe('cooldownWindow');
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable replanting policy with defaults
- seed new plants only when zone empty and cooldown passed
- expose plant seeding factory and integrate into tick orchestration

## Testing
- `npm test tests/replanting.policy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae51dfafa483258f0bb9c83538a847