### PR TITLE
feat: add react client

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Weed Breed</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "weed-breed-client",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/client/src/api/ws.js
+++ b/apps/client/src/api/ws.js
@@ -1,0 +1,72 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * Open UI websocket with auto reconnect and heartbeat.
+ * @param {object} [opts]
+ * @param {string} [opts.url] Override websocket url.
+ * @param {number} [opts.heartbeat=10000] Heartbeat timeout in ms.
+ * @returns {{messages$: Observable<string>, status$: BehaviorSubject<{status:string,lastMessageTs:number|null}> , close: ()=>void}}
+ */
+export function openUiSocket(opts = {}) {
+  const url = opts.url || import.meta.env.VITE_WS_URL || `${location.origin.replace(/^http/, 'ws')}/ws/ui`;
+  const heartbeat = opts.heartbeat ?? 10000;
+  const status$ = new BehaviorSubject({ status: 'connecting', lastMessageTs: null });
+  let ws;
+  let backoff = 500;
+  let shouldReconnect = true;
+  let hbTimer;
+
+  const connect = () => {
+    status$.next({ status: ws ? 'reconnecting' : 'connecting', lastMessageTs: status$.value.lastMessageTs });
+    ws = new WebSocket(url);
+    ws.onopen = () => {
+      backoff = 500;
+      status$.next({ status: 'connected', lastMessageTs: status$.value.lastMessageTs });
+    };
+    ws.onmessage = (ev) => {
+      status$.next({ status: 'connected', lastMessageTs: Date.now() });
+      messagesObserver?.next(ev.data);
+    };
+    ws.onerror = () => {
+      ws.close();
+    };
+    ws.onclose = () => {
+      if (!shouldReconnect) {
+        status$.next({ status: 'disconnected', lastMessageTs: status$.value.lastMessageTs });
+        messagesObserver?.complete();
+        return;
+      }
+      status$.next({ status: 'reconnecting', lastMessageTs: status$.value.lastMessageTs });
+      setTimeout(connect, backoff);
+      backoff = Math.min(backoff * 2, 5000);
+    };
+  };
+
+  const messages$ = new Observable((observer) => {
+    messagesObserver = observer;
+    connect();
+    return () => {
+      shouldReconnect = false;
+      clearInterval(hbTimer);
+      ws && ws.close();
+    };
+  });
+
+  let messagesObserver;
+  hbTimer = setInterval(() => {
+    const last = status$.value.lastMessageTs;
+    if (status$.value.status === 'connected' && last && Date.now() - last > heartbeat) {
+      status$.next({ status: 'stalling', lastMessageTs: last });
+    }
+  }, 1000);
+
+  return {
+    messages$,
+    status$,
+    close() {
+      shouldReconnect = false;
+      clearInterval(hbTimer);
+      ws && ws.close();
+    },
+  };
+}

--- a/apps/client/src/components/AppShell.jsx
+++ b/apps/client/src/components/AppShell.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Header from './Header.jsx';
+import Sidebar from './Sidebar.jsx';
+
+/**
+ * Application shell layout with header, sidebar and content.
+ * @param {{children: React.ReactNode}} props
+ */
+export default function AppShell({ children }) {
+  return (
+    <div className="app-shell">
+      <Header />
+      <div className="app-body">
+        <Sidebar />
+        <main className="app-content">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/components/Header.jsx
+++ b/apps/client/src/components/Header.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useConnection, useUiState, setPaused } from '../store/uiStore.js';
+import { fmtTick } from '../utils/format.js';
+
+/** Header with connection status and controls. */
+export default function Header() {
+  const conn = useConnection();
+  const { lastTick } = useUiState();
+  const [paused, setPausedLocal] = useState(false);
+
+  const toggle = () => {
+    setPausedLocal((p) => {
+      const np = !p;
+      setPaused(np);
+      return np;
+    });
+  };
+
+  const now = Date.now();
+  let status = conn.status;
+  if (status === 'connected' && conn.lastMessageTs && now - conn.lastMessageTs > 10000) {
+    status = 'stalling';
+  }
+
+  return (
+    <header>
+      <div>
+        <span className={`status-pill status-${status}`}>{status}</span>
+        <span style={{ marginLeft: '1rem' }}>last tick: {fmtTick(lastTick)}</span>
+      </div>
+      <div>
+        <button onClick={toggle}>{paused ? 'Resume' : 'Pause'}</button>
+        <span style={{ marginLeft: '1rem' }}>
+          {[1, 2, 3, 4, 5].map((s) => (
+            <span key={s} style={{ marginRight: '0.25rem' }}>{s}x</span>
+          ))}
+        </span>
+        <span style={{ marginLeft: '1rem' }}>balance: —</span>
+      </div>
+    </header>
+  );
+}

--- a/apps/client/src/components/KPICard.jsx
+++ b/apps/client/src/components/KPICard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * Small card to display a KPI.
+ * @param {{label:string,value:React.ReactNode}} props
+ */
+export default function KPICard({ label, value }) {
+  return (
+    <div className="kpi-card">
+      <div className="kpi-value">{value}</div>
+      <div className="kpi-label">{label}</div>
+    </div>
+  );
+}

--- a/apps/client/src/components/Sidebar.jsx
+++ b/apps/client/src/components/Sidebar.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+/** Navigation sidebar. */
+export default function Sidebar() {
+  const [hash, setHash] = useState(location.hash || '#/structure');
+  useEffect(() => {
+    const onHash = () => setHash(location.hash || '#/structure');
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  const links = [
+    ['#/structure', 'Structure'],
+    ['#/devices', 'Devices'],
+    ['#/plants', 'Plants'],
+  ];
+
+  return (
+    <nav>
+      {links.map(([href, label]) => (
+        <a key={href} href={href} className={hash.startsWith(href) ? 'active' : ''}>
+          {label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/apps/client/src/components/Table.jsx
+++ b/apps/client/src/components/Table.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+/**
+ * Simple table component.
+ * @param {{columns:Array<{key:string,label:string}>,rows:Array<Object>}} props
+ */
+export default function Table({ columns, rows }) {
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key}>{c.label}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={i}>
+            {columns.map((c) => (
+              <td key={c.key}>{r[c.key]}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/client/src/main.jsx
+++ b/apps/client/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import AppShell from './components/AppShell.jsx';
+import Router from './routes/Router.jsx';
+import { startUiStream } from './store/uiStore.js';
+import './styles.css';
+
+startUiStream();
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <AppShell>
+      <Router />
+    </AppShell>
+  </React.StrictMode>
+);

--- a/apps/client/src/routes/Router.jsx
+++ b/apps/client/src/routes/Router.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import StructureView from '../views/StructureView.jsx';
+import RoomView from '../views/RoomView.jsx';
+import ZoneView from '../views/ZoneView.jsx';
+import DevicesView from '../views/DevicesView.jsx';
+import PlantsView from '../views/PlantsView.jsx';
+
+/** Simple hash router. */
+export default function Router() {
+  const [hash, setHash] = useState(location.hash || '#/structure');
+  useEffect(() => {
+    const onHash = () => setHash(location.hash || '#/structure');
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  let View = StructureView;
+  let params = {};
+  const mRoom = hash.match(/^#\/room\/(.+)$/);
+  const mZone = hash.match(/^#\/zone\/(.+)$/);
+  if (mRoom) {
+    View = RoomView;
+    params = { roomId: mRoom[1] };
+  } else if (mZone) {
+    View = ZoneView;
+    params = { zoneId: mZone[1] };
+  } else if (hash.startsWith('#/devices')) {
+    View = DevicesView;
+  } else if (hash.startsWith('#/plants')) {
+    View = PlantsView;
+  }
+
+  return <View {...params} />;
+}

--- a/apps/client/src/store/uiStore.js
+++ b/apps/client/src/store/uiStore.js
@@ -1,0 +1,136 @@
+import { BehaviorSubject } from 'rxjs';
+import { openUiSocket } from '../api/ws.js';
+import { useEffect, useState } from 'react';
+
+/** @typedef {Object} UiState
+ * @property {number|null} lastTick
+ * @property {Record<string, number>} counters
+ * @property {Map<string, Object>} rooms
+ * @property {Map<string, Object>} zones
+ * @property {Map<string, Object>} plants
+ */
+
+/**
+ * Connection info state.
+ * @typedef {Object} ConnectionState
+ * @property {string} status
+ * @property {number|null} lastMessageTs
+ * @property {number} lastBatchSize
+ */
+
+export const connection$ = new BehaviorSubject({
+  status: 'connecting',
+  lastMessageTs: null,
+  lastBatchSize: 0,
+});
+
+export const uiState$ = new BehaviorSubject({
+  lastTick: null,
+  counters: {},
+  rooms: new Map(),
+  zones: new Map(),
+  plants: new Map(),
+});
+
+let paused = false;
+let socket;
+let sub;
+let statusSub;
+
+/** Start the websocket stream and wire to store. */
+export function startUiStream() {
+  if (socket) {
+    paused = false;
+    return;
+  }
+  socket = openUiSocket();
+  statusSub = socket.status$.subscribe((s) => {
+    connection$.next({ ...connection$.value, status: s.status, lastMessageTs: s.lastMessageTs });
+  });
+  sub = socket.messages$.subscribe((msg) => {
+    let data;
+    try {
+      data = JSON.parse(msg);
+    } catch {
+      return;
+    }
+    if (data?.type === 'ui.batch' && Array.isArray(data.events)) {
+      connection$.next({ ...connection$.value, lastBatchSize: data.events.length, lastMessageTs: Date.now() });
+      if (paused) return;
+      const next = reduceEvents(uiState$.value, data.events);
+      uiState$.next(next);
+    }
+  });
+}
+
+/** Pause incoming event processing. */
+export function setPaused(v) {
+  paused = v;
+}
+
+/** Stop stream and close socket. */
+export function closeUiStream() {
+  sub?.unsubscribe();
+  statusSub?.unsubscribe();
+  socket?.close();
+  socket = null;
+}
+
+/**
+ * Fold events into ui state.
+ * @param {UiState} state
+ * @param {Array<Object>} events
+ * @returns {UiState}
+ */
+function reduceEvents(state, events) {
+  const next = {
+    lastTick: state.lastTick,
+    counters: { ...state.counters },
+    rooms: new Map(state.rooms),
+    zones: new Map(state.zones),
+    plants: new Map(state.plants),
+  };
+  for (const ev of events) {
+    if (!ev || typeof ev !== 'object') continue;
+    if (typeof ev.tick === 'number' && (next.lastTick === null || ev.tick > next.lastTick)) {
+      next.lastTick = ev.tick;
+    }
+    if (typeof ev.type === 'string') {
+      const prefix = ev.type.split('.')[0];
+      next.counters[prefix] = (next.counters[prefix] || 0) + 1;
+    }
+    if (ev.roomId) {
+      const prev = next.rooms.get(ev.roomId) || { id: ev.roomId };
+      next.rooms.set(ev.roomId, { ...prev, ...ev });
+    }
+    if (ev.zoneId) {
+      const prev = next.zones.get(ev.zoneId) || { id: ev.zoneId, roomId: ev.roomId };
+      next.zones.set(ev.zoneId, { ...prev, ...ev });
+    }
+    if (ev.plantId) {
+      const prev = next.plants.get(ev.plantId) || { id: ev.plantId, zoneId: ev.zoneId };
+      next.plants.set(ev.plantId, { ...prev, ...ev });
+    }
+  }
+  return next;
+}
+
+/** React hook for connection state. */
+export function useConnection() {
+  const [val, setVal] = useState(connection$.value);
+  useEffect(() => {
+    const s = connection$.subscribe(setVal);
+    return () => s.unsubscribe();
+  }, []);
+  return val;
+}
+
+/** React hook for ui state. */
+export function useUiState() {
+  const [val, setVal] = useState(uiState$.value);
+  useEffect(() => {
+    const s = uiState$.subscribe(setVal);
+    return () => s.unsubscribe();
+  }, []);
+  return val;
+}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -1,0 +1,102 @@
+:root {
+  --bg: #f5f5f5;
+  --text: #222;
+  --accent: #3b82f6;
+  --card-bg: #fff;
+  --border: #ddd;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1e1e1e;
+    --text: #eee;
+    --card-bg: #2c2c2c;
+    --border: #444;
+  }
+}
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+}
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+header {
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.app-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+nav {
+  width: 200px;
+  background: #333;
+  color: #fff;
+  padding: 1rem;
+}
+nav a {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+nav a.active {
+  font-weight: bold;
+}
+.app-content {
+  flex: 1;
+  padding: 1rem;
+  overflow: auto;
+}
+.kpi-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+.kpi-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1rem;
+  margin: 0.5rem;
+  flex: 1 1 120px;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.table th, .table td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem;
+  text-align: left;
+}
+.status-pill {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  text-transform: capitalize;
+}
+.status-connected {
+  background: #16a34a;
+  color: #fff;
+}
+.status-reconnecting {
+  background: #ca8a04;
+  color: #fff;
+}
+.status-stalling {
+  background: #dc2626;
+  color: #fff;
+}

--- a/apps/client/src/utils/format.js
+++ b/apps/client/src/utils/format.js
@@ -1,0 +1,23 @@
+/** Format number with thousand separators. */
+export const fmtNumber = (n) => (n === null || n === undefined ? 'n/a' : n.toLocaleString());
+
+/** Format grams. */
+export const fmtGram = (g) => (g === null || g === undefined ? 'n/a' : `${g.toFixed(1)} g`);
+
+/** Format Celsius. */
+export const fmtCelsius = (c) => (c === null || c === undefined ? 'n/a' : `${c.toFixed(1)} °C`);
+
+/** Format percent. */
+export const fmtPercent = (p) => (p === null || p === undefined ? 'n/a' : `${(p * 100).toFixed(1)} %`);
+
+/** Format ppm. */
+export const fmtPPM = (p) => (p === null || p === undefined ? 'n/a' : `${Math.round(p)} ppm`);
+
+/** Format PPFD. */
+export const fmtPPFD = (p) => (p === null || p === undefined ? 'n/a' : `${Math.round(p)} µmol/m²/s`);
+
+/** Format DLI. */
+export const fmtDLI = (d) => (d === null || d === undefined ? 'n/a' : `${d.toFixed(1)} mol/m²/d`);
+
+/** Format tick number. */
+export const fmtTick = (t) => (t === null || t === undefined ? 'n/a' : `#${t}`);

--- a/apps/client/src/views/DevicesView.jsx
+++ b/apps/client/src/views/DevicesView.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useUiState } from '../store/uiStore.js';
+import Table from '../components/Table.jsx';
+
+/** List of devices if observed. */
+export default function DevicesView() {
+  const { zones } = useUiState();
+  const rows = [];
+  zones.forEach((z) => {
+    if (Array.isArray(z.devices)) {
+      z.devices.forEach((d) => rows.push({ id: d.id || 'n/a', name: d.name || 'n/a', zone: z.id }));
+    }
+  });
+  if (rows.length === 0) return <div>No device data.</div>;
+  return <Table columns={[{ key: 'id', label: 'ID' }, { key: 'name', label: 'Name' }, { key: 'zone', label: 'Zone' }]} rows={rows} />;
+}

--- a/apps/client/src/views/PlantsView.jsx
+++ b/apps/client/src/views/PlantsView.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useUiState } from '../store/uiStore.js';
+import Table from '../components/Table.jsx';
+import { fmtNumber, fmtGram } from '../utils/format.js';
+
+/** List of observed plants. */
+export default function PlantsView() {
+  const { plants } = useUiState();
+  const rows = [];
+  plants.forEach((p) => {
+    rows.push({
+      id: p.id,
+      age: fmtNumber(p.age_days || p.age || 0),
+      biomass: fmtGram(p.biomass_g),
+      buds: fmtGram(p.buds_g),
+    });
+  });
+  if (rows.length === 0) return <div>No plant data.</div>;
+  return (
+    <Table
+      columns={[
+        { key: 'id', label: 'ID' },
+        { key: 'age', label: 'Age (d)' },
+        { key: 'biomass', label: 'Biomass' },
+        { key: 'buds', label: 'Buds' },
+      ]}
+      rows={rows}
+    />
+  );
+}

--- a/apps/client/src/views/RoomView.jsx
+++ b/apps/client/src/views/RoomView.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useUiState } from '../store/uiStore.js';
+import Table from '../components/Table.jsx';
+import { fmtNumber, fmtCelsius, fmtPercent } from '../utils/format.js';
+
+/** View for a single room showing its zones. */
+export default function RoomView({ roomId }) {
+  const { rooms, zones, plants } = useUiState();
+  const room = rooms.get(roomId);
+  if (!room) return <div>Room {roomId} not found.</div>;
+
+  const rows = [];
+  zones.forEach((z) => {
+    if (z.roomId !== roomId) return;
+    const plantCount = Array.from(plants.values()).filter((p) => p.zoneId === z.id).length;
+    rows.push({
+      id: z.id,
+      plants: fmtNumber(plantCount),
+      temp: fmtCelsius(z.temp_C),
+      humidity: fmtPercent(z.humidity_rel),
+    });
+  });
+
+  return (
+    <div>
+      <h2>Room {roomId}</h2>
+      <Table
+        columns={[
+          { key: 'id', label: 'Zone' },
+          { key: 'plants', label: 'Plants' },
+          { key: 'temp', label: 'Temp' },
+          { key: 'humidity', label: 'Humidity' },
+        ]}
+        rows={rows}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/views/StructureView.jsx
+++ b/apps/client/src/views/StructureView.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useUiState } from '../store/uiStore.js';
+import KPICard from '../components/KPICard.jsx';
+import Table from '../components/Table.jsx';
+import { fmtNumber, fmtTick } from '../utils/format.js';
+
+/** Overall structure view with KPIs and rooms table. */
+export default function StructureView() {
+  const { lastTick, rooms, zones, plants, counters } = useUiState();
+
+  const kpis = [
+    { label: 'Last Tick', value: fmtTick(lastTick) },
+    { label: 'Rooms', value: fmtNumber(rooms.size) },
+    { label: 'Zones', value: fmtNumber(zones.size) },
+    { label: 'Plants', value: fmtNumber(plants.size) },
+    { label: 'Harvests', value: fmtNumber(counters.harvest || 0) },
+  ];
+
+  const rows = [];
+  rooms.forEach((room) => {
+    const zoneCount = Array.from(zones.values()).filter((z) => z.roomId === room.id).length;
+    const plantCount = Array.from(plants.values()).filter((p) => {
+      const z = zones.get(p.zoneId);
+      return z && z.roomId === room.id;
+    }).length;
+    rows.push({ id: room.id, zones: zoneCount, plants: plantCount, phase: room.phase || 'n/a' });
+  });
+
+  return (
+    <div>
+      <div className="kpi-grid">
+        {kpis.map((k) => (
+          <KPICard key={k.label} label={k.label} value={k.value} />
+        ))}
+      </div>
+      <Table
+        columns={[
+          { key: 'id', label: 'Room' },
+          { key: 'zones', label: 'Zones' },
+          { key: 'plants', label: 'Plants' },
+          { key: 'phase', label: 'Phase' },
+        ]}
+        rows={rows}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/views/ZoneView.jsx
+++ b/apps/client/src/views/ZoneView.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { useUiState } from '../store/uiStore.js';
+import {
+  fmtCelsius,
+  fmtPercent,
+  fmtPPM,
+  fmtPPFD,
+  fmtGram,
+  fmtNumber,
+} from '../utils/format.js';
+
+/** View for a single zone. */
+export default function ZoneView({ zoneId }) {
+  const { zones, plants } = useUiState();
+  const zone = zones.get(zoneId);
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    if (!zone) return;
+    setHistory((h) => [...h.slice(-19), zone.temp_C ?? 0]);
+  }, [zone && zone.temp_C]);
+
+  if (!zone) return <div>Zone {zoneId} not found.</div>;
+
+  const plantCount = Array.from(plants.values()).filter((p) => p.zoneId === zoneId).length;
+  const points = history.map((v, i) => `${i * 5},${50 - (v || 0)}`).join(' ');
+  const lastHarvest = zone.lastHarvestTs ? new Date(zone.lastHarvestTs).toLocaleString() : 'n/a';
+
+  return (
+    <div>
+      <h2>Zone {zoneId}</h2>
+      <div>
+        Temp: {fmtCelsius(zone.temp_C)} | Humidity: {fmtPercent(zone.humidity_rel)} | CO₂: {fmtPPM(zone.co2_ppm)} | PPFD: {fmtPPFD(zone.ppfd_umol_m2s)}
+      </div>
+      <div>
+        Plants: {fmtNumber(plantCount)} | Buds: {fmtGram(zone.buds_g)} | Biomass: {fmtGram(zone.biomass_g)} | Last harvest: {lastHarvest}
+      </div>
+      <svg width="100" height="50" style={{ marginTop: '0.5rem' }}>
+        <polyline fill="none" stroke="var(--accent)" points={points} />
+      </svg>
+    </div>
+  );
+}

--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/ws': {
+        target: 'http://localhost:3000',
+        ws: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold React 18 Vite client consuming UI websocket
- basic hash routing and layout with header and sidebar
- RxJS store with reconnecting websocket and pause support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aebbb4227883258c1022b642974b7e