### PR TITLE
feat: add simulation control api and command bus

### DIFF
--- a/apps/client/src/api/control.js
+++ b/apps/client/src/api/control.js
@@ -1,0 +1,34 @@
+const apiBase = import.meta.env.VITE_API_BASE || '';
+const token = import.meta.env.VITE_SIM_CONTROL_TOKEN;
+
+async function request(path, opts = {}) {
+  const headers = { ...(opts.headers || {}) };
+  if (token) headers['X-Sim-Control'] = token;
+  const res = await fetch(apiBase + path, { ...opts, headers });
+  if (!res.ok) throw new Error(res.statusText || 'request failed');
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+const control = {
+  start() {
+    return request('/api/sim/start', { method: 'POST' });
+  },
+  stop() {
+    return request('/api/sim/stop', { method: 'POST' });
+  },
+  setSpeed(tickMs) {
+    return request('/api/sim/speed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tickMs })
+    });
+  },
+  status() {
+    return request('/api/sim/status');
+  }
+};
+
+export default control;
+export { control };
+

--- a/apps/client/src/components/Header.jsx
+++ b/apps/client/src/components/Header.jsx
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useConnection, useUiState, setPaused } from '../store/uiStore.js';
 import { fmtTick } from '../utils/format.js';
+import control from '../api/control.js';
 
 /** Header with connection status and controls. */
 export default function Header() {
   const conn = useConnection();
   const { lastTick, lastTickSeen, paused } = useUiState();
 
+  const [server, setServer] = useState({ running: false, tickMs: null });
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState('');
+
   const toggle = () => setPaused(!paused);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function poll() {
+      try {
+        const s = await control.status();
+        if (!cancelled) setServer(s);
+      } catch {}
+      if (!cancelled) setTimeout(poll, 4000);
+    }
+    poll();
+    return () => { cancelled = true; };
+  }, []);
 
   const now = Date.now();
   let status = conn.status;
@@ -17,17 +35,49 @@ export default function Header() {
 
   const label = (lastTickSeen === null) ? 'Start' : (paused ? 'Resume' : 'Pause');
 
+  const play = async () => {
+    setBusy(true); setMsg('');
+    try { await control.start(); setServer({ ...server, running: true }); setMsg('started'); }
+    catch { setMsg('start failed'); }
+    finally { setBusy(false); }
+  };
+
+  const stop = async () => {
+    setBusy(true); setMsg('');
+    try { await control.stop(); setServer({ ...server, running: false }); setMsg('stopped'); }
+    catch { setMsg('stop failed'); }
+    finally { setBusy(false); }
+  };
+
+  const changeSpeed = async (ms) => {
+    setBusy(true); setMsg('');
+    try { await control.setSpeed(ms); setServer({ ...server, tickMs: ms }); setMsg(`speed ${ms}ms`); }
+    catch { setMsg('speed failed'); }
+    finally { setBusy(false); }
+  };
+
+  const speeds = [
+    { label: '0.5x', ms: 200 },
+    { label: '1x', ms: 100 },
+    { label: '2x', ms: 50 },
+    { label: '5x', ms: 20 }
+  ];
+
   return (
     <header>
       <div>
         <span className={`status-pill status-${status}`}>{status}</span>
         <span style={{ marginLeft: '1rem' }}>last tick: {fmtTick(lastTick)}</span>
+        <span style={{ marginLeft: '1rem' }}>server: {server.running ? 'running' : 'stopped'} @ {server.tickMs ?? '?'}ms</span>
+        {msg && <span style={{ marginLeft: '1rem' }}>{msg}</span>}
       </div>
       <div>
         <button onClick={toggle}>{label}</button>
+        <button onClick={play} disabled={busy || server.running}>Play</button>
+        <button onClick={stop} disabled={busy || !server.running}>Stop</button>
         <span style={{ marginLeft: '1rem' }}>
-          {[1, 2, 3, 4, 5].map((s) => (
-            <span key={s} style={{ marginRight: '0.25rem' }}>{s}x</span>
+          {speeds.map(s => (
+            <button key={s.ms} onClick={() => changeSpeed(s.ms)} disabled={busy || s.ms === server.tickMs} style={{ marginRight: '0.25rem' }}>{s.label}</button>
           ))}
         </span>
         <span style={{ marginLeft: '1rem' }}>balance: �?"</span>

--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -5,7 +5,8 @@ export default {
   server: {
     port: 5173,
     proxy: {
-      '/ws': { target: 'http://localhost:3000', ws: true, changeOrigin: true }
+      '/ws': { target: 'http://localhost:3000', ws: true, changeOrigin: true },
+      '/api': { target: 'http://localhost:3000', changeOrigin: true }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "start": "node src/server/index.js",
     "dev": "node --watch src/server/index.js",
+    "dev:server": "node --watch src/server/index.js",
+    "dev:client": "npm run dev --prefix apps/client",
+    "dev:all": "concurrently -n server,client -c blue,green \"npm:dev:server\" \"npm:dev:client\"",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "sim:demo": "node scripts/sim_demo.mjs",
     "sim": "node scripts/sim_from_save.mjs",
@@ -31,7 +34,8 @@
   "devDependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "jest": "^30.0.5"
+    "jest": "^30.0.5",
+    "concurrently": "^8.2.1"
   },
   "packageManager": "npm@^10"
 }

--- a/src/engine/createEngine.js
+++ b/src/engine/createEngine.js
@@ -19,11 +19,14 @@ import { telemetryAdapter } from '../sim/telemetryAdapter.js';
 
 /**
  * @typedef {object} Engine
- * @property {() => void} start
+ * @property {() => Promise<void>} start
  * @property {() => void} stop
  * @property {() => boolean} isRunning
+ * @property {(ms: number) => void} setSpeed
+ * @property {() => number} getTickMs
+ * @property {() => number} getTick
  * @property {() => any} getState
- */
+*/
 
 /**
  * @param {{ savegame: any, rng: Function, tickMs: number, logger: any }} opts
@@ -32,6 +35,7 @@ import { telemetryAdapter } from '../sim/telemetryAdapter.js';
 export function createEngine({ savegame, rng, tickMs, logger }) {
   let timer = null;
   let tick = 0;
+  let tickMsCurrent = Math.max(10, Number(tickMs || 100));
   /** @type {Array<any>} */
   let zones = [];
   /** @type {any} */
@@ -144,15 +148,26 @@ export function createEngine({ savegame, rng, tickMs, logger }) {
     async start() {
       if (timer) return; // idempotent
       await ensureBuilt();
-      const ms = Math.max(10, Number(tickMs || 100));
-      timer = setInterval(() => { step().catch(() => {}); }, ms);
+      timer = setInterval(() => { step().catch(() => {}); }, tickMsCurrent);
       if (timer.unref) timer.unref();
-      logger?.info?.({ msg: 'engine started', tickMs: ms, zones: zones.length });
+      logger?.info?.({ msg: 'engine started', tickMs: tickMsCurrent, zones: zones.length });
     },
     stop() {
       if (timer) { clearInterval(timer); timer = null; logger?.info?.({ msg: 'engine stopped' }); }
     },
     isRunning() { return Boolean(timer); },
+    setSpeed(ms) {
+      const next = Math.max(10, Number(ms));
+      tickMsCurrent = next;
+      if (timer) {
+        clearInterval(timer);
+        timer = setInterval(() => { step().catch(() => {}); }, tickMsCurrent);
+        if (timer.unref) timer.unref();
+      }
+      logger?.info?.({ msg: 'engine speed set', tickMs: tickMsCurrent });
+    },
+    getTickMs() { return tickMsCurrent; },
+    getTick() { return tick; },
     getState() {
       const plants = zones.reduce((sum, z) => sum + (z.plants?.length ?? 0), 0);
       return { tick, zonesCount: zones.length, plantsCount: plants, structure, zones };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -10,6 +10,8 @@ import seedrandom from 'seedrandom';
 import { loadDefaultSavegame } from './loadSavegame.js';
 import { attachUiWs } from '../sim/uiStreamWs.js';
 import { createEngine } from '../engine/createEngine.js';
+import { register, dispatch } from '../sim/commandBus.js';
+import { createSimControlRouter } from './routes/simControl.js';
 
 /**
  * @param {{ port?: number, tickMs?: number, autoStart?: boolean, logger?: any }} opts
@@ -40,6 +42,20 @@ export async function createServerApp(opts = {}) {
 
   // Create engine
   const engine = createEngine({ savegame, rng: rngFn, tickMs, logger });
+
+  // Command bus registrations
+  register('sim.start',   ({ engine }) => { engine.start(); });
+  register('sim.stop',    ({ engine }) => { engine.stop(); });
+  register('sim.setSpeed',({ engine, payload }) => { engine.setSpeed(Number(payload?.tickMs)); });
+  register('sim.status',  ({ engine }) => ({
+    running: engine.isRunning(),
+    tick: engine.getTick(),
+    tickMs: engine.getTickMs(),
+    seed,
+    savegamePath: meta.pathResolved,
+  }));
+
+  app.use('/api/sim', createSimControlRouter({ engine, dispatch, logger, meta: { seed, savegamePath: meta.pathResolved } }));
 
   let listening = false;
 

--- a/src/server/routes/simControl.js
+++ b/src/server/routes/simControl.js
@@ -1,0 +1,55 @@
+import express from 'express';
+
+/**
+ * Create router for simulation control.
+ * @param {{ engine: any, dispatch: Function, logger?: any, meta?: any }} opts
+ */
+export function createSimControlRouter({ engine, dispatch, logger, meta }) {
+  const router = express.Router();
+  router.use(express.json());
+
+  const token = process.env.SIM_CONTROL_TOKEN;
+  let warned = false;
+  function requireControlToken(req, res, next) {
+    if (token) {
+      if (req.get('X-Sim-Control') === token) return next();
+      return res.status(401).end();
+    }
+    if (!warned) {
+      logger?.warn?.('SIM_CONTROL_TOKEN not set; allowing unauthenticated control (dev mode).');
+      warned = true;
+    }
+    next();
+  }
+
+  const call = (cmd) => dispatch(cmd, { engine, logger, meta });
+
+  router.post('/start', requireControlToken, async (req, res) => {
+    await call({ type: 'sim.start' });
+    res.json({ ok: true });
+  });
+
+  router.post('/stop', requireControlToken, async (req, res) => {
+    await call({ type: 'sim.stop' });
+    res.json({ ok: true });
+  });
+
+  router.post('/speed', requireControlToken, async (req, res) => {
+    const tickMs = Number(req.body?.tickMs);
+    if (!Number.isFinite(tickMs) || tickMs < 10) {
+      return res.status(400).json({ error: 'tickMs must be >=10' });
+    }
+    await call({ type: 'sim.setSpeed', payload: { tickMs } });
+    res.json({ ok: true, tickMs });
+  });
+
+  router.get('/status', requireControlToken, async (req, res) => {
+    const status = await call({ type: 'sim.status' });
+    res.json(status);
+  });
+
+  return router;
+}
+
+export default { createSimControlRouter };
+

--- a/src/sim/commandBus.js
+++ b/src/sim/commandBus.js
@@ -1,0 +1,35 @@
+const handlers = new Map();
+
+/**
+ * Register a command handler.
+ * @param {string} type
+ * @param {(ctx: { engine?: any, logger?: any, payload?: any }) => any|Promise<any>} fn
+ */
+export function register(type, fn) {
+  handlers.set(type, fn);
+}
+
+/**
+ * Dispatch a command.
+ * @param {{ type: string, payload?: any }} cmd
+ * @param {{ engine?: any, logger?: any }} [ctx]
+ * @returns {Promise<any>}
+ */
+export async function dispatch(cmd, ctx = {}) {
+  const h = handlers.get(cmd?.type);
+  if (!h) throw new Error(`unknown command: ${cmd?.type}`);
+  return await h({ ...ctx, payload: cmd.payload });
+}
+
+// built-in handlers (no-ops if engine missing)
+register('sim.start', ({ engine }) => engine?.start());
+register('sim.stop', ({ engine }) => engine?.stop());
+register('sim.setSpeed', ({ engine, payload }) => engine?.setSpeed(Number(payload?.tickMs)));
+register('sim.status', ({ engine }) => ({
+  running: engine?.isRunning?.() || false,
+  tick: engine?.getTick?.() || 0,
+  tickMs: engine?.getTickMs?.(),
+}));
+
+export default { register, dispatch };
+


### PR DESCRIPTION
## Summary
- add lightweight command bus with default simulation handlers
- expose /api/sim HTTP routes for start, stop, speed and status with optional token
- wire client controls & dev scripts, enabling runtime speed changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb75ffb88832596ce2ac2ec3521c9