### PR TITLE
Add deterministic RNG wrapper and data validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Units are implicit across the data model; field names never contain unit suffixe
 
 ### Data Layout
 
+## Testing
+
+Run unit tests and ensure deterministic behaviour:
+
+```sh
+npm test
+```
+
+Validate bundled data files:
+
+```sh
+npm run validate:data
+```
+
+The simulation uses seedable random number generators. Provide the same seed to repeat runs deterministically.
+
 Strain and device definitions are split into drafts and published variants. The server writes backups before overwriting files.
 
 ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "sim:demo": "node scripts/sim_demo.mjs",
     "sim": "node scripts/sim_from_save.mjs",
     "audit:last": "node scripts/audit_last.mjs",
-    "lint": "npx eslint@8 ."
+    "lint": "npx eslint@8 .",
+    "validate:data": "node scripts/validate_data.mjs",
+    "test:unit": "npm test -- tests/unit"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/schemas/strain.schema.json
+++ b/schemas/strain.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "name"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" }
+  }
+}

--- a/scripts/validate_data.mjs
+++ b/scripts/validate_data.mjs
@@ -1,0 +1,46 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+let Ajv;
+let addFormats;
+try {
+  Ajv = (await import('ajv')).default;
+  addFormats = (await import('ajv-formats')).default;
+} catch (err) {
+  Ajv = null;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function validate() {
+  let validate;
+  const schema = JSON.parse(await fs.readFile(path.join(__dirname, '..', 'schemas', 'strain.schema.json'), 'utf8'));
+  if (Ajv) {
+    const ajv = new Ajv({ allErrors: true });
+    if (addFormats) addFormats(ajv);
+    validate = ajv.compile(schema);
+  } else {
+    validate = (data) => typeof data.id === 'string' && typeof data.name === 'string';
+  }
+  const dir = path.join(__dirname, '..', 'data', 'published', 'strains');
+  const files = await fs.readdir(dir);
+  const errors = [];
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+    const data = JSON.parse(await fs.readFile(path.join(dir, file), 'utf8'));
+    const valid = validate(data);
+    if (!valid) {
+      errors.push({ file, errors: Ajv ? validate.errors : [{ message: 'invalid data', path: '' }] });
+    }
+  }
+  if (errors.length) {
+    console.error('Validation failed');
+    for (const e of errors) {
+      console.error(`${e.file}:`, e.errors);
+    }
+    process.exit(1);
+  }
+  console.log('All data files valid');
+}
+
+validate();

--- a/src/engine/context.js
+++ b/src/engine/context.js
@@ -1,0 +1,41 @@
+import { createRng } from './rng.js';
+
+/**
+ * Factory for the tick context passed through the simulation.
+ *
+ * @typedef {Object} TickContext
+ * @property {{random: () => number}} rng Deterministic RNG instance
+ * @property {() => number} nowUtc Function returning the current time in ms
+ * @property {number} tickIndex Current tick number
+ * @property {number} tickDurationHours Duration of one tick in hours
+ * @property {Object} [envOverrides] Optional environment overrides
+ */
+
+/**
+ * Create a TickContext object.
+ *
+ * @param {Object} [opts]
+ * @param {string|number} [opts.seed] Seed for the RNG
+ * @param {number} [opts.tickIndex=0] Index of current tick
+ * @param {number} [opts.tickDurationHours=1] Tick duration in hours
+ * @param {() => number} [opts.nowUtc=Date.now] Time provider
+ * @param {Object} [opts.envOverrides] Environment overrides
+ * @returns {TickContext}
+ */
+export function createTickContext({
+  seed = 'weed-breed',
+  tickIndex = 0,
+  tickDurationHours = 1,
+  nowUtc = Date.now,
+  envOverrides,
+} = {}) {
+  return {
+    rng: createRng(seed),
+    nowUtc,
+    tickIndex,
+    tickDurationHours,
+    envOverrides,
+  };
+}
+
+export default createTickContext;

--- a/src/engine/rng.js
+++ b/src/engine/rng.js
@@ -1,0 +1,20 @@
+import seedrandom from 'seedrandom';
+
+/**
+ * Create a deterministic pseudo random number generator.
+ *
+ * @param {string|number} [seed='weed-breed'] Seed for the generator.
+ * @returns {{random: () => number}} RNG instance exposing a single `random` method.
+ */
+export function createRng(seed = 'weed-breed') {
+  const rng = seedrandom(String(seed));
+  return {
+    /**
+     * Generate a floating point number in [0,1).
+     * @returns {number}
+     */
+    random: () => rng(),
+  };
+}
+
+export default createRng;

--- a/tests/unit/Rng.test.mjs
+++ b/tests/unit/Rng.test.mjs
@@ -1,0 +1,19 @@
+import { createRng } from '../../src/engine/rng.js';
+
+describe('RNG', () => {
+  test('same seed yields identical sequences', () => {
+    const a = createRng('seed');
+    const b = createRng('seed');
+    const seqA = [a.random(), a.random(), a.random()];
+    const seqB = [b.random(), b.random(), b.random()];
+    expect(seqA).toEqual(seqB);
+  });
+
+  test('different seeds yield different sequences', () => {
+    const a = createRng('seed-a');
+    const b = createRng('seed-b');
+    const seqA = [a.random(), a.random(), a.random()];
+    const seqB = [b.random(), b.random(), b.random()];
+    expect(seqA).not.toEqual(seqB);
+  });
+});


### PR DESCRIPTION
## Summary
- add simple seedable RNG wrapper and tick context factory
- add JSON schema validation script and basic strain schema
- document test workflow and deterministic seeding

## Testing
- `npm run validate:data`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00c023fbc8325b7c0a0baf592bee7