### PR TITLE
fix(rng,env,save): normalize RNG API; split server/client env; add SAVEGAME_PATH with ESM-safe path resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-NODE_ENV=production
-LOG_LEVEL=info
-SIM_DAYS=200
-TICKS_PER_DAY=24
-# RUN_ID=20250825_093000
-WB_DATA_DIR=./data
-WB_BACKUP_RETENTION_DAYS=30
+# .env.example (client-only)
+VITE_API_BASE=http://localhost:3000
+VITE_CLIENT_NAME=Weed Breed

--- a/.env.server.example
+++ b/.env.server.example
@@ -1,0 +1,6 @@
+# .env.server.example (server-only)
+NODE_ENV=development
+SIM_SEED=wb-seed-42
+SAVEGAME_PATH=data/savegames/default.json
+TICK_LENGTH_HOURS=3
+LOG_LEVEL=info

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "type": "module",
   "main": "src/server/index.mjs",
   "scripts": {
-    "start": "node src/server/index.mjs",
-    "dev:server": "node --watch src/server/index.mjs",
-    "dev:client": "vite",
     "dev": "concurrently -k -n server,client \"npm:dev:server\" \"npm:dev:client\"",
+    "dev:server": "cross-env NODE_ENV=development node --watch src/server/index.mjs",
+    "dev:client": "vite --host",
+    "build": "vite build",
+    "start": "node src/server/index.mjs",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "sim:demo": "node scripts/sim_demo.mjs",
     "sim": "node scripts/sim_from_save.mjs",
@@ -37,7 +38,8 @@
   "devDependencies": {
     "jest": "^30.0.5",
     "concurrently": "^9.0.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "cross-env": "^7.0.3"
   },
   "engines": { "node": ">=23.0.0" },
   "packageManager": "npm@^10"

--- a/src/engine/createEngine.js
+++ b/src/engine/createEngine.js
@@ -16,6 +16,8 @@ import { CostEngine } from '../engine/CostEngine.js';
 import { createTickMachine } from '../runtime/tickMachine.js';
 import { uiStream$, emit } from '../runtime/eventBus.js';
 import { telemetryAdapter } from '../sim/telemetryAdapter.js';
+import { ensureRng } from '../lib/rng.mjs';
+import { resolveProjectPath } from '../lib/pathutil.mjs';
 
 /**
  * @typedef {object} Engine
@@ -29,10 +31,16 @@ import { telemetryAdapter } from '../sim/telemetryAdapter.js';
 */
 
 /**
- * @param {{ savegame: any, rng: Function, tickMs: number, logger: any }} opts
+ * @param {{ savegame?: any, rng?: Function, tickMs?: number, logger?: any, savegamePath?: string }} [opts]
  * @returns {Engine}
  */
-export function createEngine({ savegame, rng, tickMs, logger }) {
+export function createEngine(opts = {}) {
+  const { savegame, rng, tickMs, logger, savegamePath: savegamePathOpt } = opts;
+  const rngWrapped = ensureRng(rng);
+  const savegamePath = resolveProjectPath(
+    savegamePathOpt || process.env.SAVEGAME_PATH || 'data/savegames/default.json'
+  );
+  const config = { savegamePath };
   let timer = null;
   let tick = 0;
   let tickMsCurrent = Math.max(10, Number(tickMs || 100));
@@ -59,7 +67,7 @@ export function createEngine({ savegame, rng, tickMs, logger }) {
     const costEngine = new CostEngine({ devicePriceMap, strainPriceMap });
     const world = { totalBuds_g: 0, strainStats: new Map() };
 
-    const runtimeBase = { logger, rng, costEngine, devicePriceMap, strainPriceMap, blueprints, world };
+    const runtimeBase = { logger, rng: rngWrapped, costEngine, devicePriceMap, strainPriceMap, blueprints, world };
 
     const sg = savegame || {};
     const structCfg = sg.structure || sg.world?.structure || null;
@@ -80,7 +88,7 @@ export function createEngine({ savegame, rng, tickMs, logger }) {
           if (!bp) continue;
           const count = Number(d.count ?? 1);
           for (let i = 0; i < count; i++) {
-            const dev = createDevice(bp, { zone, tickLengthInHours: zone.tickLengthInHours, logger: zone.logger, rng }, d.overrides);
+            const dev = createDevice(bp, { zone, tickLengthInHours: zone.tickLengthInHours, logger: zone.logger, rng: rngWrapped }, d.overrides);
             zone.addDevice(dev);
           }
         }
@@ -94,7 +102,7 @@ export function createEngine({ savegame, rng, tickMs, logger }) {
           const n = Math.max(0, Math.floor((zone.area ?? 0) / areaPerPlant));
           for (let i = 0; i < n; i++) {
             // Plant ctor resolves shape internally using provided method/strain
-            const plant = new (await import('../engine/Plant.js')).Plant({ strain, method, rng, area_m2: areaPerPlant });
+            const plant = new (await import('../engine/Plant.js')).Plant({ strain, method, rng: rngWrapped, area_m2: areaPerPlant });
             zone.addPlant(plant);
           }
         }
@@ -145,6 +153,7 @@ export function createEngine({ savegame, rng, tickMs, logger }) {
   }
 
   return {
+    config,
     async start() {
       if (timer) return; // idempotent
       await ensureBuilt();

--- a/src/lib/pathutil.mjs
+++ b/src/lib/pathutil.mjs
@@ -1,0 +1,20 @@
+// src/lib/pathutil.mjs
+/**
+ * Minimal ESM-safe path helpers.
+ */
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Project root: ../../ from this file (src/lib → project root)
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * Resolve a possibly relative path against the project root.
+ * @param {string} p
+ * @returns {string} absolute path
+ */
+export function resolveProjectPath(p = '') {
+  return path.isAbsolute(p) ? p : path.resolve(PROJECT_ROOT, p);
+}

--- a/src/lib/rng.mjs
+++ b/src/lib/rng.mjs
@@ -1,0 +1,59 @@
+// src/lib/rng.mjs
+/**
+ * RNG adapter for seedrandom() to provide a uniform API:
+ * - float(min=0, max=1)
+ * - int(min, max)    [inclusive]
+ * - pick(array)
+ */
+import seedrandom from 'seedrandom';
+
+/** @typedef {{
+ *  (): number;
+ *  float?: (min?: number, max?: number) => number;
+ *  int?: (min: number, max: number) => number;
+ *  pick?: <T>(arr: T[]) => T;
+ * }} RNGLike */
+
+/**
+ * Create a wrapped RNG with a consistent API from a seed.
+ * @param {string|number} seed
+ * @returns {RNGLike}
+ */
+export function createRng(seed) {
+  const base = seedrandom(String(seed));
+  if (typeof base.float !== 'function') {
+    base.float = (min = 0, max = 1) => base() * (max - min) + min;
+  }
+  if (typeof base.int !== 'function') {
+    base.int = (min, max) => {
+      if (max < min) [min, max] = [max, min];
+      return Math.floor(base() * (max - min + 1)) + min;
+    };
+  }
+  if (typeof base.pick !== 'function') {
+    base.pick = (arr) => arr[Math.floor(base() * arr.length)];
+  }
+  return base;
+}
+
+/**
+ * Ensure an incoming rng-like has the uniform helpers attached.
+ * @param {RNGLike} rng
+ * @returns {RNGLike}
+ */
+export function ensureRng(rng) {
+  if (typeof rng !== 'function') return createRng('wb-default');
+  if (typeof rng.float !== 'function') {
+    rng.float = (min = 0, max = 1) => rng() * (max - min) + min;
+  }
+  if (typeof rng.int !== 'function') {
+    rng.int = (min, max) => {
+      if (max < min) [min, max] = [max, min];
+      return Math.floor(rng() * (max - min + 1)) + min;
+    };
+  }
+  if (typeof rng.pick !== 'function') {
+    rng.pick = (arr) => arr[Math.floor(rng() * arr.length)];
+  }
+  return rng;
+}

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,11 +1,11 @@
 /**
  * Server App factory to start/stop HTTP + WS + Engine programmatically.
  */
-import dotenv from 'dotenv';
 import http from 'node:http';
 import express from 'express';
 import pino from 'pino';
-import seedrandom from 'seedrandom';
+import { createRng } from '../lib/rng.mjs';
+import { resolveProjectPath } from '../lib/pathutil.mjs';
 
 import { loadDefaultSavegame } from './loadSavegame.js';
 import { attachUiWs } from '../sim/uiStreamWs.js';
@@ -19,8 +19,6 @@ import { ensureDataDirs } from './config.mjs';
  * @returns {Promise<{ start(): Promise<void>, stop(): Promise<void>, isRunning(): boolean, port: number, engine: any, httpServer: import('http').Server }>}
  */
 export async function createServerApp(opts = {}) {
-  // Load .env within the factory
-  dotenv.config();
   await ensureDataDirs();
 
   const logger = opts.logger || pino({ name: 'server', level: process.env.LOG_LEVEL || 'info' });
@@ -30,10 +28,13 @@ export async function createServerApp(opts = {}) {
   const tickMs = Number(opts.tickMs ?? process.env.TICK_MS ?? 100);
   const autoStart = opts.autoStart ?? (process.env.AUTO_START == null ? true : !/^false|0$/i.test(String(process.env.AUTO_START)));
 
-  const { savegame, meta } = await loadDefaultSavegame({ savegamePathEnv: process.env.SAVEGAME_PATH, logger });
+  const savegamePath = resolveProjectPath(
+    process.env.SAVEGAME_PATH || 'data/savegames/default.json'
+  );
+  logger.info({ savegamePath }, 'Using savegame path');
+  const { savegame, meta } = await loadDefaultSavegame({ savegamePathEnv: savegamePath, logger });
   const seed = process.env.SIM_SEED || meta.seed || 'weed-breed-default';
-  const rng = seedrandom(seed);
-  const rngFn = () => rng();
+  const rng = createRng(seed);
 
   // Express + HTTP server
   const app = express();
@@ -43,7 +44,7 @@ export async function createServerApp(opts = {}) {
   attachUiWs(httpServer, { path: '/ws/ui', logger });
 
   // Create engine
-  const engine = createEngine({ savegame, rng: rngFn, tickMs, logger });
+  const engine = createEngine({ savegame, rng, tickMs, logger, savegamePath });
 
   // Command bus registrations
   register('sim.start',   ({ engine }) => { engine.start(); });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1,8 +1,14 @@
 /** Thin runner that delegates to createServerApp for Electron-ready startup. */
+import { config as dotenv } from 'dotenv';
 import pino from 'pino';
 import { createServerApp } from './app.js';
 import { router as strainsRouter } from './routes/strains.mjs';
 import { router as devicesRouter } from './routes/devices.mjs';
+
+// Load server-specific env (does NOT affect Vite)
+dotenv({
+  path: ['.env.server.local', '.env.server', '.env'],
+});
 
 const logger = pino({ name: 'server', level: process.env.LOG_LEVEL || 'info' });
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,13 @@
+// vite.config.mjs
+import { defineConfig, loadEnv } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), 'VITE_');
+  return {
+    server: { host: true },
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(mode),
+      __WB_CLIENT_NAME__: JSON.stringify(env.VITE_CLIENT_NAME || 'Weed Breed'),
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- wrap seedrandom in src/lib/rng.mjs to provide float/int/pick and ensureRng helpers
- split server and client environment files, add Vite config and scripts without leaking NODE_ENV
- plumb SAVEGAME_PATH through engine with absolute path resolution via pathutil.mjs

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden fetching concurrently)*

------
https://chatgpt.com/codex/tasks/task_e_68b055691b54832599dd66fb2b7b4e21