### PR TITLE
chore(logging,dev): de-spam fallback light cycle logs; make client reliably reachable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "concurrently -k -n server,client \"npm:dev:server\" \"npm:dev:client\"",
     "dev:server": "cross-env NODE_ENV=development node --watch src/server/index.mjs",
-    "dev:client": "vite --host",
+    "dev:client": "vite --host --port 5173 --strictPort",
     "build": "vite build",
     "start": "node src/server/index.mjs",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",

--- a/src/engine/Room.js
+++ b/src/engine/Room.js
@@ -55,6 +55,7 @@ export class Room {
 
     this.zones.push(zone);
     zone.roomId = this.id;
+    zone.roomName = this.name;
     zone.structureId = this.structureId;
 
     // Pass down the contextual logger

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -395,10 +395,25 @@ export class Zone {
       } else {
         cycle = [18, 6];
       }
-      this.#log('info', { zoneId: this.id, stage }, 'Using fallback light cycle');
+      this.logger.onceKeyed(
+        `fallback:${this.roomId}:${this.id}:${stage}`,
+        'warn',
+        {
+          name: 'server',
+          structureId: this.structureId,
+          roomId: this.roomId,
+          roomName: this.roomName,
+          zoneName: this.name,
+          stage,
+        },
+        'Using fallback light cycle'
+      );
     }
 
     const currentSimHour = (tickIndex * this.tickLengthInHours) % 24;
+    if (process.env.DEBUG_LIGHT_CYCLE) {
+      this.#log('debug', { stage, cycle }, 'Light cycle tick');
+    }
     const lightHours = Number(cycle[0]) || 0;
     const lightsOn = currentSimHour < lightHours;
     this.runtime.lightsOn = lightsOn;
@@ -407,7 +422,7 @@ export class Zone {
     const lamps = this.devices.filter(d => d.kind === 'Lamp');
     if (lamps.length === 0 && !this._warnedNoLamp) {
       this._warnedNoLamp = true;
-      this.#log('warn', { zoneId: this.id }, 'No Lamp in zone; PPFD will stay ~0');
+      this.#log('warn', {}, 'No Lamp in zone; PPFD will stay ~0');
     }
     for (const lamp of lamps) {
       try {
@@ -667,7 +682,7 @@ export class Zone {
     const meanCO2ppm = this._debugDay.totalHours > 0 ? this._debugDay.co2Sum / this._debugDay.totalHours : 0;
     const meanTemp = this._debugDay.totalHours > 0 ? this._debugDay.tempSum / this._debugDay.totalHours : 0;
     if (process.env.DEBUG_HARVEST) {
-      this.logger.info({ zoneId: this.id, day, photoperiod: [lightH, darkH], meanPPFD, DLI, meanCO2ppm, meanTemp }, 'DEBUG_ZONE_DAY');
+      this.logger.info({ day, photoperiod: [lightH, darkH], meanPPFD, DLI, meanCO2ppm, meanTemp }, 'DEBUG_ZONE_DAY');
       for (const p of this.plants.slice(0, 3)) {
         p.debugDailyLog?.(day, this);
       }

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -3,6 +3,7 @@
  * @module lib/logger
  */
 import pino from 'pino';
+import { attachLogHelpers } from './logging.mjs';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -13,9 +14,9 @@ const isDev = process.env.NODE_ENV !== 'production';
  * when you need more verbose debugging information.
  * @type {import('pino').Logger}
  */
-export const logger = pino({
+export const logger = attachLogHelpers(pino({
   level: process.env.LOG_LEVEL ?? (isDev ? 'info' : 'warn'),
   transport: isDev ? { target: 'pino-pretty', options: { colorize: true } } : undefined
-});
+}));
 
 export default logger;

--- a/src/lib/logging.mjs
+++ b/src/lib/logging.mjs
@@ -1,0 +1,60 @@
+/**
+ * Logging helpers for Pino logger to avoid log spam.
+ * @module lib/logging
+ */
+
+/**
+ * Map of keys that have already been logged once.
+ * @type {Set<string>}
+ */
+const seenOnce = new Set();
+
+/**
+ * Remember last timestamps per key for rate limited logs.
+ * @type {Map<string, number>}
+ */
+const lastSeen = new Map();
+
+/**
+ * Attach helper methods to a Pino logger instance.
+ *
+ * @param {import('pino').Logger} logger - The logger to extend.
+ * @returns {import('pino').Logger} The same logger instance for chaining.
+ */
+export function attachLogHelpers(logger) {
+  /**
+   * Log only once per unique key during the process lifetime.
+   *
+   * @param {string} key - Unique identifier for the log event.
+   * @param {import('pino').Level} [level='warn'] - Pino log level to use.
+   * @param {object} [obj] - Structured log object.
+   * @param {string} [msg] - Human readable message.
+   */
+  logger.onceKeyed = function onceKeyed(key, level = 'warn', obj, msg) {
+    if (seenOnce.has(key)) return;
+    seenOnce.add(key);
+    this[level]?.(obj, msg);
+  };
+
+  /**
+   * Create a logger function that is rate limited per key.
+   *
+   * @param {string} key - Identifier used for tracking last log time.
+   * @param {number} intervalMs - Minimum interval between logs in milliseconds.
+   * @returns {(level: import('pino').Level, obj?: object, msg?: string) => void}
+   *   Function that logs at most once per interval.
+   */
+  logger.rateLimit = function rateLimit(key, intervalMs) {
+    return (level = 'info', obj, msg) => {
+      const now = Date.now();
+      const last = lastSeen.get(key) || 0;
+      if (now - last < intervalMs) return;
+      lastSeen.set(key, now);
+      this[level]?.(obj, msg);
+    };
+  };
+
+  return logger;
+}
+
+export default { attachLogHelpers };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,7 +3,9 @@
  */
 import http from 'node:http';
 import express from 'express';
+import cors from 'cors';
 import pino from 'pino';
+import { attachLogHelpers } from '../lib/logging.mjs';
 import { createRng } from '../lib/rng.mjs';
 import { resolveProjectPath } from '../lib/pathutil.mjs';
 
@@ -21,7 +23,7 @@ import { ensureDataDirs } from './config.mjs';
 export async function createServerApp(opts = {}) {
   await ensureDataDirs();
 
-  const logger = opts.logger || pino({ name: 'server', level: process.env.LOG_LEVEL || 'info' });
+  const logger = opts.logger || attachLogHelpers(pino({ name: 'server', level: process.env.LOG_LEVEL || 'info' }));
 
   // Resolve env/opts
   const port = Number(opts.port ?? process.env.PORT ?? 3000);
@@ -39,6 +41,11 @@ export async function createServerApp(opts = {}) {
   // Express + HTTP server
   const app = express();
   const httpServer = http.createServer(app);
+
+  app.use(cors({ origin: true, credentials: true }));
+  app.get('/healthz', (req, res) => {
+    res.json({ ok: true, uptime_s: process.uptime(), pid: process.pid });
+  });
 
   // Attach WS forwarder (read-only telemetry)
   attachUiWs(httpServer, { path: '/ws/ui', logger });
@@ -68,7 +75,10 @@ export async function createServerApp(opts = {}) {
         httpServer.listen(port, resolve);
       });
       listening = true;
-      logger.info({ msg: 'server listening', port, seed, tickMs, savegamePath: meta.pathResolved });
+      logger.info(
+        { name: 'server', port, vitePort: 5173, env: process.env.NODE_ENV, logLevel: logger.level },
+        'Server listening'
+      );
     }
     if (autoStart !== false && !engine.isRunning()) {
       await engine.start();

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1,6 +1,7 @@
 /** Thin runner that delegates to createServerApp for Electron-ready startup. */
 import { config as dotenv } from 'dotenv';
 import pino from 'pino';
+import { attachLogHelpers } from '../lib/logging.mjs';
 import { createServerApp } from './app.js';
 import { router as strainsRouter } from './routes/strains.mjs';
 import { router as devicesRouter } from './routes/devices.mjs';
@@ -11,6 +12,7 @@ dotenv({
 });
 
 const logger = pino({ name: 'server', level: process.env.LOG_LEVEL || 'info' });
+attachLogHelpers(logger);
 
 async function main() {
   const port = Number(process.env.PORT || 3000);

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
   return {
-    server: { host: true },
+    server: { host: true, strictPort: true, port: 5173 },
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode),
       __WB_CLIENT_NAME__: JSON.stringify(env.VITE_CLIENT_NAME || 'Weed Breed'),


### PR DESCRIPTION
## Summary
- add logging helpers with onceKeyed and rateLimit to tame log spam
- wire helpers into server and library loggers
- warn once per zone when using fallback light cycle and clean up duplicate fields
- expose /healthz, allow CORS for vite, and log server start succinctly
- bind Vite to host:5173 with strict port and update dev script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b05a8702d08325bd746e7c0daab04f