### PR TITLE
fix(dev): serve client from /frontend with Vite; remove 404 on :5173

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "dev": "concurrently -k -n server,client \"npm:dev:server\" \"npm:dev:client\"",
     "dev:server": "cross-env NODE_ENV=development node --watch src/server/index.mjs",
-    "dev:client": "vite --host --port 5173 --strictPort",
-    "build": "vite build",
+    "dev:client": "vite --config vite.config.mjs",
+    "build": "vite build --config vite.config.mjs",
+    "preview": "vite preview --config vite.config.mjs",
     "start": "node src/server/index.mjs",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "sim:demo": "node scripts/sim_demo.mjs",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,13 +1,47 @@
 // vite.config.mjs
 import { defineConfig, loadEnv } from 'vite';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = __dirname;
+
+// Client lives in /frontend
+const clientRoot = path.resolve(projectRoot, 'frontend');
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), 'VITE_');
+  // Only load VITE_* variables for client
+  const env = loadEnv(mode, projectRoot, 'VITE_');
+  const apiBase = env.VITE_API_BASE || 'http://localhost:3000';
+
   return {
-    server: { host: true, strictPort: true, port: 5173 },
-    define: {
-      'process.env.NODE_ENV': JSON.stringify(mode),
-      __WB_CLIENT_NAME__: JSON.stringify(env.VITE_CLIENT_NAME || 'Weed Breed'),
+    root: clientRoot,
+    base: '/',
+    server: {
+      host: true,
+      port: 5173,
+      strictPort: true,
+      proxy: {
+        '/api': {
+          target: apiBase,
+          changeOrigin: true
+        }
+      }
     },
+    preview: {
+      port: 5173,
+      strictPort: true
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(clientRoot, 'src')
+      }
+    },
+    define: {
+      // Safe fallback for rare client code paths checking NODE_ENV
+      'process.env.NODE_ENV': JSON.stringify(mode)
+    }
   };
 });
+


### PR DESCRIPTION
## Summary
- serve Vite client from `frontend/` with explicit root/port and /api proxy
- run client dev/build/preview via shared `vite.config.mjs`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b05fed4ccc8325bdea05b6438ffcaf