### PR TITLE
refactor: move client sim scripts out of public

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -20,12 +20,12 @@
     </div>
     <script type="module" src="/src/main.jsx"></script>
     <script type="module">
-      import { mountSimToggle } from '/js/simToggle.js';
+      import { mountSimToggle } from '/src/lib/simToggle.js';
       const btn = document.getElementById('sim-toggle');
       const statusEl = document.getElementById('sim-status');
       const speedBtns = [...document.querySelectorAll('[data-speed]')];
       mountSimToggle(btn, statusEl, speedBtns);
     </script>
-    <script type="module" src="/js/strainEditor.js"></script>
+    <script type="module" src="/src/dev/strainEditorBoot.js"></script>
   </body>
 </html>

--- a/apps/client/src/dev/strainEditorBoot.js
+++ b/apps/client/src/dev/strainEditorBoot.js
@@ -1,4 +1,4 @@
-// apps/client/public/js/strainEditor.js
+// apps/client/src/dev/strainEditorBoot.js
 const SHOW = (import.meta?.env?.VITE_SHOW_STRAIN_EDITOR ?? 'true') === 'true';
 const apiBase = import.meta?.env?.VITE_API_BASE || `${window.location.protocol}//${window.location.hostname}:3000`;
 

--- a/apps/client/src/lib/simApi.js
+++ b/apps/client/src/lib/simApi.js
@@ -1,32 +1,52 @@
-// apps/client/public/js/simApi.js
-const apiBase = import.meta?.env?.VITE_API_BASE || `${window.location.protocol}//${window.location.hostname}:3000`;
+// apps/client/src/lib/simApi.js
+// REST + WS helpers for simulation control (ESM). Works in Vite (src).
+
+const apiBase =
+  import.meta?.env?.VITE_API_BASE ||
+  `${window.location.protocol}//${window.location.hostname}:3000`;
+
 const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-const wsUrl = import.meta?.env?.VITE_WS_URL || `${wsProto}//${window.location.hostname}:3000/ws/ui`;
+const wsUrl =
+  import.meta?.env?.VITE_WS_URL || `${wsProto}//${window.location.hostname}:3000/ws/ui`;
 
 export async function getState() {
   const res = await fetch(`${apiBase}/api/sim/state`);
   return res.json();
 }
+
 export async function start(speed) {
-  const res = await fetch(`${apiBase}/api/sim/start`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ speed }) });
+  const res = await fetch(`${apiBase}/api/sim/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ speed }),
+  });
   return res.json();
 }
+
 export async function pause() {
   const res = await fetch(`${apiBase}/api/sim/pause`, { method: 'POST' });
   return res.json();
 }
+
 export async function resume() {
   const res = await fetch(`${apiBase}/api/sim/resume`, { method: 'POST' });
   return res.json();
 }
+
 export async function stop() {
   const res = await fetch(`${apiBase}/api/sim/stop`, { method: 'POST' });
   return res.json();
 }
+
 export async function setSpeed(speed) {
-  const res = await fetch(`${apiBase}/api/sim/speed`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ speed }) });
+  const res = await fetch(`${apiBase}/api/sim/speed`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ speed }),
+  });
   return res.json();
 }
+
 export function openUiWs(onMessage) {
   const ws = new WebSocket(wsUrl);
   ws.onmessage = (ev) => {

--- a/apps/client/src/lib/simToggle.js
+++ b/apps/client/src/lib/simToggle.js
@@ -1,8 +1,10 @@
-// apps/client/public/js/simToggle.js
+// apps/client/src/lib/simToggle.js
+// Vanilla single-toggle mount helper for non-React pages/sections.
+
 import { getState, start, pause, resume, stop, setSpeed, openUiWs } from './simApi.js';
 
 /**
- * Mounts a single toggle button and an optional small stop element.
+ * Mounts a single toggle button and optional stop element & speed buttons.
  * @param {HTMLButtonElement} btn
  * @param {HTMLElement} statusEl
  * @param {HTMLElement[]} speedButtons elements with data-speed="2" etc.
@@ -14,37 +16,34 @@ export async function mountSimToggle(btn, statusEl, speedButtons = []) {
 
   const stopEl = document.querySelector('[data-sim-stop]');
 
-  function labelFor(s) {
-    if (s === 'running') return 'Pause';
-    if (s === 'paused') return 'Resume';
-    return 'Start';
-  }
+  const labelFor = (s) => (s === 'running' ? 'Pause' : s === 'paused' ? 'Resume' : 'Start');
+
   function render() {
-    btn.textContent = labelFor(state);
+    if (btn) btn.textContent = labelFor(state);
     if (stopEl) stopEl.style.display = (state === 'running' || state === 'paused') ? '' : 'none';
     if (statusEl) statusEl.textContent = `State: ${state} | Tick: ${tick} | Speed: ${speed}x`;
   }
+
   async function refresh() {
     try {
       const s = await getState();
-      state = s.state; tick = s.tick; speed = s.speed;
+      state = s.state ?? 'idle';
+      tick  = s.tick ?? 0;
+      speed = s.speed ?? 1;
     } catch {}
     render();
   }
 
-  btn.addEventListener('click', async () => {
-    if (state === 'idle') await start(speed);
+  btn?.addEventListener('click', async () => {
+    if (state === 'idle')       await start(speed);
     else if (state === 'running') await pause();
-    else if (state === 'paused') await resume();
+    else if (state === 'paused')  await resume();
     await refresh();
   });
 
-  if (stopEl) stopEl.addEventListener('click', async () => {
-    await stop();
-    await refresh();
-  });
+  stopEl?.addEventListener('click', async (e) => { e.preventDefault(); await stop(); await refresh(); });
 
-  speedButtons.forEach(el => {
+  speedButtons.forEach((el) => {
     el.addEventListener('click', async () => {
       const v = Number(el.dataset.speed);
       if (Number.isFinite(v) && v > 0) {
@@ -55,11 +54,15 @@ export async function mountSimToggle(btn, statusEl, speedButtons = []) {
     });
   });
 
-  // WS telemetry (optional)
+  // WS tick telemetry
   openUiWs((evt) => {
-    if (evt?.type === 'sim.tickCompleted') {
-      tick = evt.payload?.tick ?? tick;
-      render();
+    const last = Array.isArray(evt) ? evt[evt.length - 1] : evt;
+    if (last?.type === 'sim.tickCompleted') {
+      const t = last?.payload?.tick;
+      if (Number.isFinite(t)) {
+        tick = t;
+        render();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- move simApi and simToggle modules from public to src/lib
- update client index.html to import modules from /src
- migrate strain editor bootstrap to src and drop public/js

## Testing
- `npm test`
- `npm run dev:client`


------
https://chatgpt.com/codex/tasks/task_e_68b1154558d88325ad171b3b8bf275d4