### PR TITLE
feat(client): add src path alias

### DIFF
--- a/apps/client/vite.config.js
+++ b/apps/client/vite.config.js
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   server: {
     port: 5173,
     host: true,


### PR DESCRIPTION
## Summary
- add path import and src alias in client Vite config

## Testing
- `npm test`
- `npm --prefix apps/client run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b1d82267248325afadbd5570c9c6e2