### PR TITLE
Unpause UI stream on socket connect

### DIFF
--- a/apps/client/src/store/uiStore.js
+++ b/apps/client/src/store/uiStore.js
@@ -51,6 +51,8 @@ export function startUiStream() {
     return;
   }
   socket = openUiSocket();
+  paused = false;
+  uiState$.next({ ...uiState$.value, paused });
   statusSub = socket.status$.subscribe((s) => {
     connection$.next({ ...connection$.value, status: s.status, lastMessageTs: s.lastMessageTs });
   });


### PR DESCRIPTION
## Summary
- Unpause UI event stream immediately after opening WebSocket

## Testing
- `npm test`
- `node --input-type=module <manual test script>`


------
https://chatgpt.com/codex/tasks/task_e_68b1da2fe000832584441c98a3755c11