### PR TITLE
fix: use relative path for client script

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- reference the React entry module with a relative path in `apps/client/index.html`

## Testing
- `npm test`
- `npm run dev:client` & `curl http://localhost:5173/src/main.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1db61dc7c832583536444a3e61515