### PR TITLE
Serve static client from Express server

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -3,11 +3,16 @@ import express from 'express';
 import http from 'node:http';
 import cors from 'cors';
 import bodyParser from 'body-parser';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { attachUiWs } from '../sim/uiStreamWs.js';
 import { createSimController } from './simControl.mjs';
 import { createStrainRouter } from './strainRouter.mjs';
 
 const PORT = Number(process.env.PORT || 3000);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(cors());
@@ -18,6 +23,12 @@ const sim = createSimController();
 app.use('/api/sim', sim.router);
 app.use('/api/strains', createStrainRouter().router);
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
+
+// Serve built client
+app.use(express.static(path.resolve(__dirname, '../../dist/client')));
+app.use((_req, res) => {
+  res.sendFile(path.resolve(__dirname, '../../dist/client/index.html'));
+});
 
 const server = http.createServer(app);
 


### PR DESCRIPTION
## Summary
- serve built client assets via Express static middleware
- fall back to index.html for unmatched routes

## Testing
- `npm test`
- `npm run build`
- `npm run start` and `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68b1dec8512083259315cdda22550dca