### PR TITLE
Handle UI socket connection errors

### DIFF
--- a/apps/client/src/store/uiStore.js
+++ b/apps/client/src/store/uiStore.js
@@ -50,7 +50,12 @@ export function startUiStream() {
     uiState$.next({ ...uiState$.value, paused });
     return;
   }
-  socket = openUiSocket();
+  try {
+    socket = openUiSocket();
+  } catch {
+    connection$.next({ status: 'error' });
+    return;
+  }
   paused = false;
   uiState$.next({ ...uiState$.value, paused });
   statusSub = socket.status$.subscribe((s) => {


### PR DESCRIPTION
## Summary
- handle websocket connection errors in `startUiStream` and report `status: 'error'`

## Testing
- `npm test`
- `node --input-type=module -e "import { startUiStream, connection$ } from './apps/client/src/store/uiStore.js'; startUiStream(); console.log(connection$.value);"`


------
https://chatgpt.com/codex/tasks/task_e_68b1e0265ae883259c57925c4d0c8c5a