### PR TITLE
docs(client): clarify Vite serving requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ npm run dev
 // src/server/index.mjs
 [src/server/index.mjs](src/server/index.mjs)
 
+The client is served through [Vite](https://vitejs.dev/). To run only the
+frontend during development, start the Vite dev server:
+
+```sh
+npm run dev:client
+```
+
+Opening `apps/client/index.html` directly in the browser will not load the
+modules correctly; always use the dev server or a production build.
+
 ### Logging
 
 The default log level is conservative (`warn`) to keep the console output tidy.

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -1,4 +1,8 @@
 <!doctype html>
+<!--
+  This file must be served through Vite (e.g. `npm run dev:client`) or a
+  production build. Opening it directly in a browser will fail to load modules.
+-->
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,6 +11,12 @@
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <p style="color: red; text-align: center;">
+        JavaScript is required for Weed Breed. Serve this file via Vite or use a
+        built bundle.
+      </p>
+    </noscript>
     <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- warn that `apps/client/index.html` must be served by Vite or a production build
- document `npm run dev:client` in the README
- add a noscript message for browsers without modules

## Testing
- `npm test -- --color=false >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b1e1ac492c8325bef9583b33a83097