### PR TITLE
chore: migrate JSON imports to Node 23 import attributes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
-  "env": { "es2023": true, "node": true, "jest": true },
-  "parserOptions": { "ecmaVersion": "latest", "sourceType": "module" },
+  "env": { "es2024": true, "node": true, "jest": true },
+  "parserOptions": { "ecmaVersion": 2024, "sourceType": "module" },
   "extends": ["eslint:recommended"],
   "rules": {
     "no-restricted-imports": ["error", {

--- a/CHANGES_NODE23_JSON_IMPORTS.md
+++ b/CHANGES_NODE23_JSON_IMPORTS.md
@@ -1,0 +1,5 @@
+# Node v23 JSON Import Changes
+
+- `.eslintrc.json`: enable `ecmaVersion: 2024` and `es2024` env for import attributes.
+- `src/server/index.mjs`: use `with { type: 'json' }` for `package.json` import and log package version at startup.
+- `packages/wb-model/index.js`: switch schema exports to `with { type: 'json' }`.

--- a/REPORT_NODE23_JSON_IMPORTS.md
+++ b/REPORT_NODE23_JSON_IMPORTS.md
@@ -1,0 +1,15 @@
+# Node v23 JSON Import Migration Report
+
+## Findings before fixes
+
+| File | Line | Original snippet | Strategy | Notes |
+| --- | --- | --- | --- | --- |
+| src/server/index.mjs | 11 | `import pkg from '../../package.json' assert { type: 'json' };` | Static JSON import switched to `with { type: 'json' }`. | Used for health endpoint and startup log. |
+| packages/wb-model/index.js | 2-5 | `export { ... } from "./schemas/*.json" assert { type: "json" };` | Static exports switched to `with { type: 'json' }`. | Package consumed on server side. |
+| apps/client/src/components/StrainEditor.jsx | 10 | `import schema from '@/schemas/strain.schema.json';` | Left unchanged. | Client bundler (Vite) already handles JSON modules. |
+| scripts/validate_data.mjs | 17 | `JSON.parse(await fs.readFile(...))` | Already uses `fs/promises`; no change. | Dynamic load, path resolved at runtime. |
+
+## Risks & Boundaries
+
+- No `require()` calls for JSON were found.
+- Client-facing code remains untouched to avoid bundler regressions.

--- a/packages/wb-model/index.js
+++ b/packages/wb-model/index.js
@@ -1,8 +1,8 @@
 // ESM – keine Sim-Logik!
-export { default as strainSchema } from "./schemas/strain.schema.json" assert { type: "json" };
-export { default as deviceSchema } from "./schemas/device.schema.json" assert { type: "json" };
-export { default as cultivationMethodSchema } from "./schemas/cultivation_method.schema.json" assert { type: "json" };
-export { default as strainPricesSchema } from "./schemas/strainPrices.schema.json" assert { type: "json" };
+export { default as strainSchema } from "./schemas/strain.schema.json" with { type: "json" };
+export { default as deviceSchema } from "./schemas/device.schema.json" with { type: "json" };
+export { default as cultivationMethodSchema } from "./schemas/cultivation_method.schema.json" with { type: "json" };
+export { default as strainPricesSchema } from "./schemas/strainPrices.schema.json" with { type: "json" };
 // Optional: konstante Konventionen, Validator-Fabrik:
 export { envConventions } from "./constants/env.js";
 export { createValidator } from "./runtime/validate.js";

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 import { attachUiWs } from '../sim/uiStreamWs.js';
 import { createSimController } from './simControl.mjs';
 import { createStrainRouter } from './strainRouter.mjs';
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 const PORT = Number(process.env.PORT || 7071);
 
@@ -40,5 +40,5 @@ const server = http.createServer(app);
 attachUiWs(server, { path: '/ui', logger: console });
 
 server.listen(PORT, () => {
-  console.log(`[server] listening on http://localhost:${PORT}`);
+  console.log(`[server] v${pkg.version} listening on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- replace deprecated JSON import assertions with `with { type: 'json' }`
- log package version on server startup
- document Node 23 JSON import scan and changes

## Testing
- `npm test`
- `npm run dev:server`
- `curl -s http://localhost:7071/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68b1eaa5876c8325bafe708f23ba50a6