### PR TITLE
fix(client): remove JSON import attributes in JSX and keep Ajv 2020-12 setup

### DIFF
--- a/apps/client/src/components/StrainEditor.jsx
+++ b/apps/client/src/components/StrainEditor.jsx
@@ -2,20 +2,18 @@ import React, { useMemo, useState } from 'react'
 import ajv from '@/lib/ajv2020.js'
 import { registerSchemas, compileWith } from '@/lib/schemaRegistry.js'
 
-// Root schema (adjust the path/name to your actual schema file)
-import strainSchema from '@/schemas/strain.schema.json' assert { type: 'json' }
+// Root schema (no import attributes)
+import strainSchema from '@/schemas/strain.schema.json'
 
-// If your strain schema $ref other local schemas, import them here and register.
-// Example (uncomment and adjust if present):
-// import deviceSchema from '@/schemas/device.schema.json' assert { type: 'json' }
-// import cultivationMethodSchema from '@/schemas/cultivation_method.schema.json' assert { type: 'json' }
+// If your strain schema $ref other local schemas, import them here (no assert)
+// Example (uncomment/adjust if present):
+// import deviceSchema from '@/schemas/device.schema.json'
+// import cultivationMethodSchema from '@/schemas/cultivation_method.schema.json'
 // registerSchemas(ajv, deviceSchema, cultivationMethodSchema)
 
-// Compile once per module (or useMemo if schema can change at runtime)
 const validate = compileWith(ajv, strainSchema)
 
-// Small demo state so you can see validation working right away
-const exampleValid = /** @type {any} */ ({
+const exampleValid = {
   id: 'strain-demo-1',
   name: 'Demo Strain',
   genotype: { sativa: 0.4, indica: 0.6, ruderalis: 0.0 },
@@ -23,23 +21,19 @@ const exampleValid = /** @type {any} */ ({
   morphology: { growthRate: 1.0, yieldFactor: 1.0, leafAreaIndex: 2.0 },
   environmentalPreferences: {
     idealTemperature: { vegetation: [22, 28], flowering: [22, 28] },
-    idealHumidity: { vegetation: [0.5, 0.65], flowering: [0.5, 0.65] }
+    idealHumidity: { vegetation: [0.5, 0.65], flowering: [0.5, 0.65] },
   },
   vegetationDays: 21,
-  floweringDays: 56
-})
+  floweringDays: 56,
+}
 
-const exampleInvalid = /** @type {any} */ ({
-  id: 123, // should be string
-  name: null, // should be string
-})
+const exampleInvalid = { id: 123, name: null }
 
 export default function StrainEditor() {
-  const [value, setValue] = useState(exampleValid)
   const [raw, setRaw] = useState(JSON.stringify(exampleValid, null, 2))
 
   const result = useMemo(() => {
-    let parsed = value
+    let parsed
     try {
       parsed = JSON.parse(raw)
     } catch {
@@ -55,7 +49,7 @@ export default function StrainEditor() {
       <div style={row}>
         <div style={col}>
           <div style={label}>JSON</div>
-          <textarea style={ta} value={raw} onChange={e => setRaw(e.target.value)} />
+          <textarea style={ta} value={raw} onChange={(e) => setRaw(e.target.value)} />
           <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
             <button onClick={() => setRaw(JSON.stringify(exampleValid, null, 2))}>Load valid</button>
             <button onClick={() => setRaw(JSON.stringify(exampleInvalid, null, 2))}>Load invalid</button>
@@ -63,10 +57,13 @@ export default function StrainEditor() {
         </div>
         <div style={col}>
           <div style={label}>Validation</div>
-          <p>Valid: <b style={{ color: result.ok ? 'green' : 'crimson' }}>{String(result.ok)}</b></p>
-          {!result.ok && (
-            <pre style={pre}>{JSON.stringify(result.errors, null, 2)}</pre>
-          )}
+          <p>
+            Valid:{' '}
+            <b style={{ color: result.ok ? 'green' : 'crimson' }}>
+              {String(result.ok)}
+            </b>
+          </p>
+          {!result.ok && <pre style={pre}>{JSON.stringify(result.errors, null, 2)}</pre>}
         </div>
       </div>
     </div>
@@ -77,5 +74,18 @@ const wrap = { fontFamily: 'system-ui, sans-serif', padding: 12, lineHeight: 1.4
 const row = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, alignItems: 'start' }
 const col = { display: 'flex', flexDirection: 'column' }
 const label = { fontSize: 12, opacity: 0.7, margin: '8px 0' }
-const ta = { minHeight: 260, fontFamily: 'ui-monospace, Menlo, Consolas, monospace', fontSize: 12, padding: 8 }
-const pre = { background: '#0b0e14', color: '#d6deeb', padding: 12, borderRadius: 8, fontSize: 12, maxHeight: 320, overflow: 'auto' }
+const ta = {
+  minHeight: 260,
+  fontFamily: 'ui-monospace, Menlo, Consolas, monospace',
+  fontSize: 12,
+  padding: 8,
+}
+const pre = {
+  background: '#0b0e14',
+  color: '#d6deeb',
+  padding: 12,
+  borderRadius: 8,
+  fontSize: 12,
+  maxHeight: 320,
+  overflow: 'auto',
+}

--- a/apps/client/src/lib/ajv2020.js
+++ b/apps/client/src/lib/ajv2020.js
@@ -1,7 +1,7 @@
 // Central Ajv instance for JSON Schema Draft 2020-12 (ESM + Vite)
 import Ajv2020 from 'ajv/dist/2020'
 import addFormats from 'ajv-formats'
-import meta2020 from 'ajv/dist/refs/json-schema-2020-12.json' assert { type: 'json' }
+import meta2020 from 'ajv/dist/refs/json-schema-2020-12.json'
 
 /**
  * Create a single Ajv instance for the whole app.
@@ -13,13 +13,9 @@ const ajv = new Ajv2020({
   allErrors: true,
   strict: false,
   allowUnionTypes: true,
-  // loadSchema undefined: no remote $ref loading
 })
 
-// Register the 2020-12 meta schema so $schema can resolve properly
 ajv.addMetaSchema(meta2020)
-
-// Enable common string/number/date formats
 addFormats(ajv)
 
 export default ajv


### PR DESCRIPTION
## Summary
- remove deprecated JSON import attributes from client code
- compile and register JSON schemas via central Ajv 2020-12 setup

## Testing
- `npm test`
- `npm run dev:client`

------
https://chatgpt.com/codex/tasks/task_e_68b3d8cb557c832581fc9e373bbc4736