### PR TITLE
refactor: simplify ajv setup

### DIFF
--- a/apps/client/src/components/StrainEditor.jsx
+++ b/apps/client/src/components/StrainEditor.jsx
@@ -1,17 +1,17 @@
 import React, { useMemo, useState } from 'react'
 import ajv from '@/lib/ajv2020.js'
-import { registerSchemas, compileWith } from '@/lib/schemaRegistry.js'
 
-// Root schema (no import attributes)
+// Root schema (plain JSON import; no import attributes)
 import strainSchema from '@/schemas/strain.schema.json'
 
-// If your strain schema $ref other local schemas, import them here (no assert)
-// Example (uncomment/adjust if present):
+// If your root schema uses $ref to other local schemas, import and register them here:
 // import deviceSchema from '@/schemas/device.schema.json'
 // import cultivationMethodSchema from '@/schemas/cultivation_method.schema.json'
-// registerSchemas(ajv, deviceSchema, cultivationMethodSchema)
+// ajv.addSchema(deviceSchema)
+// ajv.addSchema(cultivationMethodSchema)
 
-const validate = compileWith(ajv, strainSchema)
+// Compile once
+const validate = ajv.compile(strainSchema)
 
 const exampleValid = {
   id: 'strain-demo-1',

--- a/apps/client/src/lib/ajv2020.js
+++ b/apps/client/src/lib/ajv2020.js
@@ -1,13 +1,11 @@
 // Central Ajv instance for JSON Schema Draft 2020-12 (ESM + Vite)
 import Ajv2020 from 'ajv/dist/2020'
 import addFormats from 'ajv-formats'
-import meta2020 from 'ajv/dist/refs/json-schema-2020-12.json'
 
 /**
- * Create a single Ajv instance for the whole app.
- * - Draft 2020-12 with the meta schema explicitly registered
- * - Common formats enabled
- * - Non-strict: we validate content, not police the schema itself
+ * Ajv2020 already includes draft-2020-12 support.
+ * We intentionally DO NOT import any meta JSON from node_modules
+ * to avoid Vite dependency scan issues with deep JSON imports.
  */
 const ajv = new Ajv2020({
   allErrors: true,
@@ -15,7 +13,7 @@ const ajv = new Ajv2020({
   allowUnionTypes: true,
 })
 
-ajv.addMetaSchema(meta2020)
+// Enable common formats (email, uri, date-time, etc.)
 addFormats(ajv)
 
 export default ajv


### PR DESCRIPTION
## Summary
- simplify Ajv 2020-12 setup for client, removing meta-schema import
- unify JSON imports and update StrainEditor to use the central Ajv instance

## Testing
- `npm test`
- `npm run dev:client`

------
https://chatgpt.com/codex/tasks/task_e_68b3df172cb08325a0021da4f1e24fe9