### PR TITLE
feat(client): add simulation controls to header

### DIFF
--- a/apps/client/src/components/Header.jsx
+++ b/apps/client/src/components/Header.jsx
@@ -1,24 +1,111 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSocketDiagnostics } from '@/lib/socket.js'
+import { useSimState, startSim, pauseSim, stepSim, setSpeed } from '@/lib/simControl.js'
 
 export default function Header() {
   const diag = useSocketDiagnostics()
+  const [sim, setSim] = useSimState()
+  const [busy, setBusy] = useState(false)
+  const disabled = !diag.connected || busy
+
+  async function doStart() {
+    try {
+      setBusy(true)
+      await startSim()
+    } catch (e) {
+      setSim((s) => ({ ...s, error: e?.message || String(e) }))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function doPause() {
+    try {
+      setBusy(true)
+      await pauseSim()
+    } catch (e) {
+      setSim((s) => ({ ...s, error: e?.message || String(e) }))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function doStep() {
+    try {
+      setBusy(true)
+      await stepSim()
+    } catch (e) {
+      setSim((s) => ({ ...s, error: e?.message || String(e) }))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function onSpeedChange(e) {
+    const val = Number(e.target.value)
+    setSim((s) => ({ ...s, speed: val }))
+    try {
+      await setSpeed(val)
+    } catch (e2) {
+      setSim((s) => ({ ...s, error: e2?.message || String(e2) }))
+    }
+  }
+
   return (
     <div style={bar}>
       <span style={{ fontWeight: 600 }}>Weed Breed</span>
-      <span>
-        WS:{' '}
-        <b style={{ color: diag.connected ? 'limegreen' : 'crimson' }}>
-          {diag.connected ? 'connected' : 'disconnected'}
-        </b>
-        {' · '}events: {diag.eventCount} {' · '}last: <code>{diag.lastEventType ?? '—'}</code>
-      </span>
+
+      <div style={controls}>
+        <button onClick={doStart} disabled={disabled || sim.running} title="Start (Space)">
+          ▶ Start
+        </button>
+        <button onClick={doPause} disabled={disabled || !sim.running} title="Pause (Space)">
+          ❚❚ Pause
+        </button>
+        <button onClick={doStep} disabled={!diag.connected || sim.running || busy} title="Step (.)">
+          ▷ Step
+        </button>
+
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          <span>Speed</span>
+          <input
+            type="range"
+            min="0.25"
+            max="8"
+            step="0.25"
+            value={sim.speed}
+            onChange={onSpeedChange}
+            disabled={!diag.connected || busy}
+          />
+          <code>{sim.speed.toFixed(2)}x</code>
+        </label>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>
+          WS:{' '}
+          <b style={{ color: diag.connected ? 'limegreen' : 'crimson' }}>
+            {diag.connected ? 'connected' : 'disconnected'}
+          </b>
+          {' · '}events: {diag.eventCount} {' · '}last: <code>{diag.lastEventType ?? '—'}</code>
+        </span>
+      </div>
+
+      {/* Statuszeile */}
+      <div style={status}>
+        <span>
+          {sim.running ? 'running' : 'paused'} · lastTick:{' '}
+          <code>{sim.lastTick ?? 'n/a'}</code>
+        </span>
+        {sim.error && <span style={{ color: 'salmon' }}>error: {sim.error}</span>}
+      </div>
     </div>
   )
 }
+
 const bar = {
-  display: 'flex',
-  justifyContent: 'space-between',
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
   alignItems: 'center',
   gap: 12,
   padding: '8px 12px',
@@ -28,4 +115,16 @@ const bar = {
   position: 'sticky',
   top: 0,
   zIndex: 10,
+}
+
+const controls = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+}
+
+const status = {
+  gridColumn: '1 / -1',
+  fontSize: 12,
+  opacity: 0.8,
 }

--- a/apps/client/src/lib/simControl.js
+++ b/apps/client/src/lib/simControl.js
@@ -1,0 +1,64 @@
+import { socket } from '@/lib/socket.js'
+import { useEffect, useState } from 'react'
+
+const ACK_TIMEOUT_MS = 2000
+
+function emitWithAck(event, payload) {
+  return new Promise((resolve, reject) => {
+    socket.timeout(ACK_TIMEOUT_MS).emit(event, payload, (err, ack) => {
+      if (err) return reject(err)
+      resolve(ack)
+    })
+  })
+}
+
+/** Client APIs */
+export async function startSim() {
+  return emitWithAck('sim.control', { action: 'start' })
+}
+export async function pauseSim() {
+  return emitWithAck('sim.control', { action: 'pause' })
+}
+export async function stepSim() {
+  return emitWithAck('sim.step', {})
+}
+export async function setSpeed(multiplier) {
+  return emitWithAck('sim.speed', { multiplier })
+}
+
+/**
+ * useSimState:
+ * - subscribed to 'sim.state' and 'sim.tickCompleted'
+ * - provides { running, speed, lastTick, error }
+ */
+export function useSimState() {
+  const [state, setState] = useState({
+    running: false,
+    speed: 1,
+    lastTick: null,
+    error: null,
+  })
+
+  useEffect(() => {
+    const onState = (s) => {
+      setState((prev) => ({
+        ...prev,
+        ...s,
+        error: null,
+      }))
+    }
+    const onTick = (payload) => {
+      const t = payload?.tick ?? Date.now()
+      setState((prev) => ({ ...prev, lastTick: t }))
+    }
+    socket.on('sim.state', onState)
+    socket.on('sim.tickCompleted', onTick)
+
+    return () => {
+      socket.off('sim.state', onState)
+      socket.off('sim.tickCompleted', onTick)
+    }
+  }, [])
+
+  return [state, setState]
+}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -100,3 +100,15 @@ nav a.active {
   background: #dc2626;
   color: #fff;
 }
+button {
+  padding: 4px 8px;
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- add simControl utilities with Socket.IO ACKs
- extend header with Start/Pause/Step buttons and speed slider
- neutral button styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ed200acc832584c18fa08e90522b