### PR TITLE
feat(sim): add controllable simulation loop with socket.io

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1,12 +1,16 @@
+// Node ESM + Socket.IO v4 server exposing sim controls
 import http from 'node:http'
 import express from 'express'
 import cors from 'cors'
 import { Server as IOServer } from 'socket.io'
+import { SimEngine } from './simEngine.mjs'
 
 const PORT = Number(process.env.PORT || 7071)
-const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui' // wichtig: /ui
+const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui'
+const BASE_MS = Number(process.env.TICK_WALL_MS || 200)
 
 const app = express()
+// CORS for Vite client
 app.use(cors({ origin: ['http://localhost:5173'], credentials: true }))
 app.get('/healthz', (_req, res) => res.json({ ok: true, message: 'server up' }))
 
@@ -14,27 +18,92 @@ const httpServer = http.createServer(app)
 
 const io = new IOServer(httpServer, {
   path: SOCKET_PATH,
+  transports: ['polling', 'websocket'],
+  allowEIO3: false,
   cors: {
     origin: ['http://localhost:5173'],
     methods: ['GET', 'POST'],
     credentials: true,
   },
-  transports: ['polling', 'websocket'], // Polling erlaubt → später Upgrade
-  allowEIO3: false, // wir setzen auf EIO4 (socket.io v4)
 })
+
+// -- Simulation core
+const sim = new SimEngine(io, { baseMs: BASE_MS })
 
 io.on('connection', (socket) => {
   console.log('[io] connected', socket.id)
+
+  // send current state immediately
+  socket.emit('sim.state', sim.state())
+
+  // control: start/pause
+  socket.on('sim.control', (payload = {}, ack) => {
+    try {
+      const action = String(payload?.action || '').toLowerCase()
+      if (action === 'start') {
+        sim.start()
+        sim.broadcastState()
+        if (typeof ack === 'function') ack({ ok: true })
+        return
+      }
+      if (action === 'pause') {
+        sim.pause()
+        sim.broadcastState()
+        if (typeof ack === 'function') ack({ ok: true })
+        return
+      }
+      if (typeof ack === 'function') ack({ ok: false, error: 'unknown action' })
+    } catch (err) {
+      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+    }
+  })
+
+  // single step (only when paused)
+  socket.on('sim.step', (_payload, ack) => {
+    try {
+      if (sim.running) {
+        if (typeof ack === 'function') return ack({ ok: false, error: 'pause first' })
+        return
+      }
+      sim.step()
+      // optional: reflect tick change via state (UI may also rely on sim.tickCompleted)
+      sim.broadcastState()
+      if (typeof ack === 'function') ack({ ok: true })
+    } catch (err) {
+      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+    }
+  })
+
+  // speed change
+  socket.on('sim.speed', (payload = {}, ack) => {
+    try {
+      const m = Number(payload?.multiplier)
+      sim.setSpeed(m)
+      sim.broadcastState()
+      if (typeof ack === 'function') ack({ ok: true })
+    } catch (err) {
+      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+    }
+  })
+
   socket.on('disconnect', (reason) => {
     console.log('[io] disconnected', socket.id, reason)
   })
 })
 
-// Demo-Events (sichtbarer "Herzschlag")
-setInterval(() => {
-  io.emit('sim.tickCompleted', { tick: Date.now() })
-}, 1500)
+// demo: you can choose to start paused; leave it paused by default
+// sim.start()
 
 httpServer.listen(PORT, () => {
-  console.log(`[server] http://localhost:${PORT}  ws path=${SOCKET_PATH}`)
+  console.log(`[server] http://localhost:${PORT}  ws path=${SOCKET_PATH}  baseMs=${BASE_MS}`)
 })
+
+// graceful shutdown
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    console.log(`[server] ${sig} received, shutting down...`)
+    sim.dispose()
+    httpServer.close(() => process.exit(0))
+  })
+}
+

--- a/src/server/simEngine.mjs
+++ b/src/server/simEngine.mjs
@@ -1,0 +1,103 @@
+// Simple controllable simulation loop with Socket.IO v4
+// ESM module
+export class SimEngine {
+  /**
+   * @param {import('socket.io').Server} io
+   * @param {{ baseMs?: number }} options
+   */
+  constructor(io, { baseMs = 200 } = {}) {
+    this.io = io
+    this.baseMs = Number.isFinite(baseMs) ? baseMs : 200
+    this.running = false
+    this.speed = 1.0
+    this.tick = 0
+    this._timer = null
+
+    this._performTick = this._performTick.bind(this)
+  }
+
+  /** Current delay in ms, considering speed (floored at 16ms) */
+  get delayMs() {
+    const d = this.baseMs / Math.max(0.0001, this.speed)
+    return Math.max(16, Math.round(d))
+  }
+
+  /** Emit one tick and schedule next if running */
+  _performTick() {
+    try {
+      const payload = { tick: this.tick, at: Date.now() }
+      this.io.emit('sim.tickCompleted', payload)
+      this.tick += 1
+    } catch (err) {
+      // Log and continue
+      console.error('[sim] tick error:', err?.stack || err)
+    } finally {
+      // Schedule next only if running
+      if (this.running) {
+        this._timer = setTimeout(this._performTick, this.delayMs)
+      }
+    }
+  }
+
+  /** Start the loop (no-op if already running) */
+  start() {
+    if (this.running) return
+    this.running = true
+    clearTimeout(this._timer)
+    // run ASAP
+    this._timer = setTimeout(this._performTick, 0)
+  }
+
+  /** Pause the loop (no-op if already paused) */
+  pause() {
+    if (!this.running) return
+    this.running = false
+    clearTimeout(this._timer)
+    this._timer = null
+  }
+
+  /** Single tick while paused */
+  step() {
+    if (this.running) {
+      throw new Error('cannot step while running')
+    }
+    // Do not schedule the next tick (running=false)
+    this._performTick()
+  }
+
+  /**
+   * @param {number} m
+   */
+  setSpeed(m) {
+    const next = Number(m)
+    if (!Number.isFinite(next) || next <= 0) {
+      throw new Error('invalid speed multiplier')
+    }
+    // clamp 0.25 .. 16
+    this.speed = Math.min(16, Math.max(0.25, next))
+    if (this.running) {
+      clearTimeout(this._timer)
+      this._timer = setTimeout(this._performTick, this.delayMs)
+    }
+  }
+
+  /** Current state snapshot */
+  state() {
+    return {
+      running: this.running,
+      speed: this.speed,
+      tick: this.tick,
+    }
+  }
+
+  /** Broadcast state to all clients */
+  broadcastState() {
+    this.io.emit('sim.state', this.state())
+  }
+
+  /** Clean shutdown */
+  dispose() {
+    this.pause()
+  }
+}
+


### PR DESCRIPTION
## Summary
- add SimEngine to drive simulation ticks with configurable speed
- expose Socket.IO server to control simulation start/pause/step/speed and broadcast state

## Testing
- `npm test`
- `node src/server/index.mjs & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68b3ff293780832597c3dd55cc1bf5be