### PR TITLE
Add default savegame bootstrap and world summary sync

### DIFF
--- a/apps/client/src/components/Header.jsx
+++ b/apps/client/src/components/Header.jsx
@@ -1,33 +1,29 @@
 import React, { useState } from 'react'
 import { useSocketDiagnostics } from '@/lib/socket.js'
 import { useSimState, startSim, pauseSim, stepSim, setSpeed } from '@/lib/simControl.js'
+import { loadDefaultSavegame, useWorldSummary } from '@/lib/worldControl.js'
 
 export default function Header() {
   const diag = useSocketDiagnostics()
+  const summary = useWorldSummary()
   const [sim, setSim] = useSimState()
   const [busy, setBusy] = useState(false)
   const disabled = !diag.connected || busy
 
   async function doStart() {
-    try {
-      setBusy(true); await startSim()
-    } catch (e) {
-      setSim((s) => ({ ...s, error: e?.message || String(e) }))
-    } finally { setBusy(false) }
+    try { setBusy(true); await startSim() }
+    catch (e) { setSim((s) => ({ ...s, error: e?.message || String(e) })) }
+    finally { setBusy(false) }
   }
   async function doPause() {
-    try {
-      setBusy(true); await pauseSim()
-    } catch (e) {
-      setSim((s) => ({ ...s, error: e?.message || String(e) }))
-    } finally { setBusy(false) }
+    try { setBusy(true); await pauseSim() }
+    catch (e) { setSim((s) => ({ ...s, error: e?.message || String(e) })) }
+    finally { setBusy(false) }
   }
   async function doStep() {
-    try {
-      setBusy(true); await stepSim()
-    } catch (e) {
-      setSim((s) => ({ ...s, error: e?.message || String(e) }))
-    } finally { setBusy(false) }
+    try { setBusy(true); await stepSim() }
+    catch (e) { setSim((s) => ({ ...s, error: e?.message || String(e) })) }
+    finally { setBusy(false) }
   }
   async function onSpeedChange(e) {
     const val = Number(e.target.value)
@@ -35,32 +31,31 @@ export default function Header() {
     try { await setSpeed(val) }
     catch (e2) { setSim((s) => ({ ...s, error: e2?.message || String(e2) })) }
   }
+  async function doLoadDefault() {
+    try { setBusy(true); await loadDefaultSavegame() }
+    catch (e) { setSim((s) => ({ ...s, error: e?.message || String(e) })) }
+    finally { setBusy(false) }
+  }
 
   return (
     <div style={bar}>
       <span style={{ fontWeight: 600 }}>Weed Breed</span>
 
       <div style={controls}>
-        <button onClick={doStart} disabled={disabled || sim.running} title="Start">
-          ▶ Start
-        </button>
-        <button onClick={doPause} disabled={disabled || !sim.running} title="Pause">
-          ❚❚ Pause
-        </button>
-        <button onClick={doStep} disabled={!diag.connected || sim.running || busy} title="Step">
-          ▷ Step
-        </button>
+        <button onClick={doStart} disabled={disabled || sim.running} title="Start">▶ Start</button>
+        <button onClick={doPause} disabled={disabled || !sim.running} title="Pause">❚❚ Pause</button>
+        <button onClick={doStep} disabled={!diag.connected || sim.running || busy} title="Step">▷ Step</button>
 
         <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
           <span>Speed</span>
-          <input
-            type="range" min="0.25" max="8" step="0.25"
-            value={sim.speed}
-            onChange={onSpeedChange}
-            disabled={!diag.connected || busy}
-          />
+          <input type="range" min="0.25" max="8" step="0.25"
+            value={sim.speed} onChange={onSpeedChange} disabled={!diag.connected || busy} />
           <code>{sim.speed.toFixed(2)}x</code>
         </label>
+
+        <button onClick={doLoadDefault} disabled={!diag.connected || busy} title="Load default save">
+          ⟳ Load Default
+        </button>
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -80,7 +75,12 @@ export default function Header() {
         <span>
           {sim.running ? 'running' : 'paused'} · lastTick: <code>{sim.lastTick ?? 'n/a'}</code>
         </span>
-        {sim.error && <span style={{ color: 'salmon' }}>error: {sim.error}</span>}
+        {summary && (
+          <span style={{ marginLeft: 16 }}>
+            rooms: <b>{summary.rooms}</b> · zones: <b>{summary.zones}</b> · plants: <b>{summary.plants}</b> · harvests: <b>{summary.harvests}</b>
+          </span>
+        )}
+        {sim.error && <span style={{ color: 'salmon', marginLeft: 16 }}>error: {sim.error}</span>}
       </div>
     </div>
   )

--- a/apps/client/src/lib/worldControl.js
+++ b/apps/client/src/lib/worldControl.js
@@ -1,0 +1,32 @@
+import { socket } from '@/lib/socket.js'
+import { useEffect, useState } from 'react'
+
+const ACK_TIMEOUT_MS = 2000
+
+function emitWithAck(event, payload) {
+  return new Promise((resolve, reject) => {
+    socket.timeout(ACK_TIMEOUT_MS).emit(event, payload, (err, ack) => {
+      if (err) return reject(err)
+      resolve(ack)
+    })
+  })
+}
+
+/** Loads the default savegame (or a specific path via payload.path) on the server. */
+export async function loadDefaultSavegame(path) {
+  const payload = path ? { path } : {}
+  const res = await emitWithAck('savegame.load', payload)
+  if (!res?.ok) throw new Error(res?.error || 'load failed')
+  return res
+}
+
+/** Hook that subscribes to 'world.summary'. */
+export function useWorldSummary() {
+  const [summary, setSummary] = useState(null)
+  useEffect(() => {
+    const onSummary = (s) => setSummary(s)
+    socket.on('world.summary', onSummary)
+    return () => socket.off('world.summary', onSummary)
+  }, [])
+  return summary
+}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1,16 +1,22 @@
-// Node ESM + Socket.IO v4 server exposing sim controls
+// Node ESM + Socket.IO v4 server with simulation controls and savegame loading
 import http from 'node:http'
 import express from 'express'
 import cors from 'cors'
 import { Server as IOServer } from 'socket.io'
 import { SimEngine } from './simEngine.mjs'
+import {
+  getDefaultSavePath,
+  ensureSampleSave,
+  loadWorldFromFile,
+  computeSummary,
+} from './savegame.mjs'
 
 const PORT = Number(process.env.PORT || 7071)
 const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui'
 const BASE_MS = Number(process.env.TICK_WALL_MS || 200)
+const SAVE_PATH = process.env.SAVEGAME_PATH || getDefaultSavePath()
 
 const app = express()
-// CORS for Vite client
 app.use(cors({ origin: ['http://localhost:5173'], credentials: true }))
 app.get('/healthz', (_req, res) => res.json({ ok: true, message: 'server up' }))
 
@@ -27,62 +33,88 @@ const io = new IOServer(httpServer, {
   },
 })
 
-// -- Simulation core
+// --- Simulation core
 const sim = new SimEngine(io, { baseMs: BASE_MS })
 
+// --- World state (loaded from disk)
+let world = null
+let summary = { rooms: 0, zones: 0, plants: 0, harvests: 0 }
+
+// Load default save at startup (create a sample if missing)
+function bootstrapWorld() {
+  try {
+    ensureSampleSave(SAVE_PATH)
+    world = loadWorldFromFile(SAVE_PATH)
+    summary = computeSummary(world)
+    console.log('[world] loaded', SAVE_PATH, summary)
+  } catch (err) {
+    console.error('[world] failed to load', SAVE_PATH, err?.message || err)
+    world = { meta: { id: 'empty' }, structure: { rooms: [] }, metrics: { harvests: 0 } }
+    summary = computeSummary(world)
+  }
+}
+
+// Broadcast summary to all clients
+function broadcastSummary() {
+  io.emit('world.summary', summary)
+}
+
+// Handle socket connections
 io.on('connection', (socket) => {
   console.log('[io] connected', socket.id)
 
-  // send current state immediately
+  // Initial state to the new client
   socket.emit('sim.state', sim.state())
+  socket.emit('world.summary', summary)
 
-  // control: start/pause
+  // sim controls (ACK)
   socket.on('sim.control', (payload = {}, ack) => {
     try {
       const action = String(payload?.action || '').toLowerCase()
       if (action === 'start') {
-        sim.start()
-        sim.broadcastState()
-        if (typeof ack === 'function') ack({ ok: true })
-        return
+        sim.start(); io.emit('sim.state', sim.state())
+        return typeof ack === 'function' && ack({ ok: true })
       }
       if (action === 'pause') {
-        sim.pause()
-        sim.broadcastState()
-        if (typeof ack === 'function') ack({ ok: true })
-        return
+        sim.pause(); io.emit('sim.state', sim.state())
+        return typeof ack === 'function' && ack({ ok: true })
       }
-      if (typeof ack === 'function') ack({ ok: false, error: 'unknown action' })
+      return typeof ack === 'function' && ack({ ok: false, error: 'unknown action' })
     } catch (err) {
-      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+      return typeof ack === 'function' && ack({ ok: false, error: err?.message || String(err) })
     }
   })
 
-  // single step (only when paused)
   socket.on('sim.step', (_payload, ack) => {
     try {
-      if (sim.running) {
-        if (typeof ack === 'function') return ack({ ok: false, error: 'pause first' })
-        return
-      }
-      sim.step()
-      // optional: reflect tick change via state (UI may also rely on sim.tickCompleted)
-      sim.broadcastState()
-      if (typeof ack === 'function') ack({ ok: true })
+      if (sim.running) return typeof ack === 'function' && ack({ ok: false, error: 'pause first' })
+      sim.step(); io.emit('sim.state', sim.state())
+      return typeof ack === 'function' && ack({ ok: true })
     } catch (err) {
-      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+      return typeof ack === 'function' && ack({ ok: false, error: err?.message || String(err) })
     }
   })
 
-  // speed change
   socket.on('sim.speed', (payload = {}, ack) => {
     try {
-      const m = Number(payload?.multiplier)
-      sim.setSpeed(m)
-      sim.broadcastState()
-      if (typeof ack === 'function') ack({ ok: true })
+      sim.setSpeed(Number(payload?.multiplier))
+      io.emit('sim.state', sim.state())
+      return typeof ack === 'function' && ack({ ok: true })
     } catch (err) {
-      if (typeof ack === 'function') ack({ ok: false, error: err?.message || String(err) })
+      return typeof ack === 'function' && ack({ ok: false, error: err?.message || String(err) })
+    }
+  })
+
+  // Load/savegame (ACK) – loads from optional path, else default path
+  socket.on('savegame.load', (payload = {}, ack) => {
+    try {
+      const p = payload?.path || SAVE_PATH
+      world = loadWorldFromFile(p)
+      summary = computeSummary(world)
+      broadcastSummary()
+      return typeof ack === 'function' && ack({ ok: true, summary, path: p })
+    } catch (err) {
+      return typeof ack === 'function' && ack({ ok: false, error: err?.message || String(err) })
     }
   })
 
@@ -91,11 +123,13 @@ io.on('connection', (socket) => {
   })
 })
 
-// demo: you can choose to start paused; leave it paused by default
-// sim.start()
+// Boot
+bootstrapWorld()
+// sim.start() // optional auto-start
 
 httpServer.listen(PORT, () => {
   console.log(`[server] http://localhost:${PORT}  ws path=${SOCKET_PATH}  baseMs=${BASE_MS}`)
+  console.log(`[server] savegame: ${SAVE_PATH}`)
 })
 
 // graceful shutdown
@@ -106,4 +140,3 @@ for (const sig of ['SIGINT', 'SIGTERM']) {
     httpServer.close(() => process.exit(0))
   })
 }
-

--- a/src/server/savegame.mjs
+++ b/src/server/savegame.mjs
@@ -1,0 +1,69 @@
+// ESM helper to load/save a "world" from JSON and compute a summary.
+import fs from 'node:fs'
+import path from 'node:path'
+
+/** Absolute default save path (cwd/data/savegames/default.json) */
+export function getDefaultSavePath() {
+  return path.resolve(process.cwd(), 'data', 'savegames', 'default.json')
+}
+
+/** Ensure a sample savegame exists at the target path (idempotent). */
+export function ensureSampleSave(filePath = getDefaultSavePath()) {
+  if (fs.existsSync(filePath)) return
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const sample = {
+    meta: { id: 'save-default-001', createdAt: new Date().toISOString(), version: 1 },
+    structure: {
+      rooms: [
+        {
+          id: 'room-A',
+          name: 'Room A',
+          zones: [
+            {
+              id: 'zone-A1',
+              name: 'A1',
+              plants: [
+                { id: 'plant-001', strainId: 'strain-demo-1', stage: 'vegetation' },
+                { id: 'plant-002', strainId: 'strain-demo-1', stage: 'vegetation' }
+              ]
+            },
+            {
+              id: 'zone-A2',
+              name: 'A2',
+              plants: [
+                { id: 'plant-003', strainId: 'strain-demo-1', stage: 'flowering' }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    metrics: { harvests: 0 }
+  }
+  fs.writeFileSync(filePath, JSON.stringify(sample, null, 2), 'utf8')
+}
+
+/** Load a world JSON from disk. Throws on error. */
+export function loadWorldFromFile(filePath = getDefaultSavePath()) {
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const world = JSON.parse(raw)
+  return world
+}
+
+/** Compute a simple summary for dashboard counters. */
+export function computeSummary(world) {
+  const rooms = world?.structure?.rooms ?? []
+  const roomCount = rooms.length
+  let zoneCount = 0
+  let plantCount = 0
+  for (const r of rooms) {
+    const zones = r?.zones ?? []
+    zoneCount += zones.length
+    for (const z of zones) {
+      const plants = z?.plants ?? []
+      plantCount += plants.length
+    }
+  }
+  const harvests = Number(world?.metrics?.harvests ?? 0)
+  return { rooms: roomCount, zones: zoneCount, plants: plantCount, harvests }
+}


### PR DESCRIPTION
## Summary
- load default savegame on server startup and create sample if missing
- expose savegame summary via Socket.IO and implement client hook
- add header button to reload default savegame and display room/zone/plant counters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b402fae4d08325bbaf6085034fb285