### PR TITLE
fix(server): robust default save bootstrap

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1,10 +1,13 @@
 import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 import cors from 'cors'
 import { Server as IOServer } from 'socket.io'
 import { SimEngine } from './simEngine.mjs'
 import {
-  getDefaultSavePath,
+  resolveExistingDefaultSavePath,
   ensureSampleSave,
   loadWorldFromFile,
   computeSummary,
@@ -14,7 +17,7 @@ import {
 const PORT = Number(process.env.PORT || 7071)
 const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui'
 const BASE_MS = Number(process.env.TICK_WALL_MS || 200)
-const SAVE_PATH = process.env.SAVEGAME_PATH || getDefaultSavePath()
+const SAVE_PATH = process.env.SAVEGAME_PATH || resolveExistingDefaultSavePath()
 
 const app = express()
 app.use(cors({ origin: ['http://localhost:5173'], credentials: true }))
@@ -43,20 +46,32 @@ function broadcastWorld() {
   io.emit('world.snapshot', snapshot)
 }
 function bootstrap() {
+  const exists = fs.existsSync(SAVE_PATH)
+  const cwd = process.cwd()
+  const dir = path.dirname(fileURLToPath(import.meta.url))
+  console.info('[startup] cwd=%s dir=%s', cwd, dir)
+  console.info('[startup] resolved SAVE_PATH=%s exists=%s', SAVE_PATH, exists)
   ensureSampleSave(SAVE_PATH)
   world = loadWorldFromFile(SAVE_PATH)
   recompute()
-  console.log('[world]', summary)
+  console.info(
+    '[startup] loaded summary: rooms=%d zones=%d plants=%d harvests=%d snapshotRooms=%d',
+    summary.rooms,
+    summary.zones,
+    summary.plants,
+    summary.harvests,
+    snapshot?.rooms?.length ?? 0,
+  )
 }
 
 bootstrap()
 broadcastWorld()
 
 io.on('connection', (socket) => {
-  console.log('[io] connected', socket.id)
   socket.emit('sim.state', sim.state())
   socket.emit('world.summary', summary)
   socket.emit('world.snapshot', snapshot)
+  console.log('[io] connected', socket.id)
 
   socket.on('sim.control', (p={}, ack)=>{ try{
     const a = String(p.action||'').toLowerCase()
@@ -75,6 +90,7 @@ io.on('connection', (socket) => {
   }catch(e){ return ack?.({ok:false,error:e?.message||String(e)})}})
 
   socket.on('world.get', (_p, ack)=> ack?.({ok:true, summary, snapshot}))
+  socket.on('world.debug', (_p, ack)=> ack?.({ ok:true, path:SAVE_PATH, summary, snapshotRooms:snapshot?.rooms?.length ?? 0 }))
 
   socket.on('savegame.load', (p={}, ack)=>{ try{
     const file = p?.path || SAVE_PATH

--- a/src/server/savegame.mjs
+++ b/src/server/savegame.mjs
@@ -1,9 +1,22 @@
 // ESM helpers for savegames and derived views
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export function getDefaultSavePath() {
   return path.resolve(process.cwd(), 'data', 'savegames', 'default.json')
+}
+
+export function resolveExistingDefaultSavePath() {
+  const candidates = [
+    path.resolve(process.cwd(), 'data', 'savegames', 'default.json'),
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../data/savegames/default.json'),
+    path.resolve(process.cwd(), 'apps', 'server', 'data', 'savegames', 'default.json'),
+  ]
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p
+  }
+  return getDefaultSavePath()
 }
 
 export function ensureSampleSave(filePath = getDefaultSavePath()) {
@@ -35,8 +48,13 @@ export function computeSummary(world) {
   const rooms = world?.structure?.rooms ?? []
   const roomCount = rooms.length
   let zoneCount = 0
-  let plantCount = 0 // echte Pflanzeninstanzen sind im Save nicht vorhanden → 0
-  for (const r of rooms) zoneCount += (r?.zones ?? []).length
+  let plantCount = 0
+  for (const r of rooms) {
+    for (const z of r?.zones ?? []) {
+      zoneCount++
+      if (Array.isArray(z?.plants)) plantCount += z.plants.length
+    }
+  }
   const harvests = Number(world?.metrics?.harvests ?? 0)
   return { rooms: roomCount, zones: zoneCount, plants: plantCount, harvests }
 }
@@ -60,16 +78,30 @@ export function computeSnapshot(world) {
   for (const r of rooms) {
     const zones = r?.zones ?? []
     const outZones = zones.map((z) => {
+      const plants = Array.isArray(z?.plants) ? z.plants : []
+      const plantsCount = plants.length
+      let phase = null
+      if (plantsCount > 0) {
+        const counts = {}
+        for (const p of plants) {
+          const st = p?.stage
+          if (st) counts[st] = (counts[st] || 0) + 1
+        }
+        phase = Object.entries(counts).sort((a,b)=>b[1]-a[1])[0]?.[0] || null
+      }
       const sim = z?.simulation || {}
       const strainId = sim.strainId || null
       const strainLabel = labelFromZoneName(z?.name, strainId)
       const methodId = sim.methodId || null
       const methodLabel = humanizeMethod(methodId)
-      return {
+      const zoneSnap = {
         id: z.id, name: z.name,
+        plantsCount,
         strainId, strainLabel,
         methodId, methodLabel,
       }
+      if (phase) zoneSnap.phase = phase
+      return zoneSnap
     })
     outRooms.push({ id: r.id, name: r.name, zones: outZones })
   }


### PR DESCRIPTION
## Summary
- load default save from first existing path via `resolveExistingDefaultSavePath`
- improve world summary/snapshot to handle plant or simulation data structures
- log savegame path diagnostics on startup and expose `world.debug` socket event

## Testing
- `npm test`
- `node src/server/index.mjs` *(fails: we terminated after verifying startup logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b47ab0387c832596b8aa67db7d4347