### PR TITLE
feat(ui,server): show planned plants & devices per zone; vertical zone list; cache-based world fetch

### DIFF
--- a/apps/client/src/lib/worldControl.js
+++ b/apps/client/src/lib/worldControl.js
@@ -6,16 +6,40 @@ const ack = (ev,p={}) => new Promise((resolve,reject)=>{
   socket.timeout(ACK_TIMEOUT_MS).emit(ev,p,(err,res)=> err?reject(err):resolve(res))
 })
 
-export const loadDefaultSavegame = (path) => ack('savegame.load', path?{path}:{})
+export const loadDefaultSavegame = (path) => ack('savegame.load', path ? { path } : {})
 export const requestWorld = () => ack('world.get', {})
 
+let lastSummary = null
+let lastSnapshot = null
+
 export function useWorldSummary() {
-  const [summary, setSummary] = useState(null)
-  useEffect(()=>{ const h=(s)=>setSummary(s); socket.on('world.summary',h); return ()=>socket.off('world.summary',h)},[])
+  const [summary, setSummary] = useState(lastSummary)
+  useEffect(() => {
+    const onSummary = (s) => { lastSummary = s; setSummary(s) }
+    const onConnect = () => requestWorld().catch(() => {})
+    socket.on('world.summary', onSummary)
+    socket.on('connect', onConnect)
+    if (!lastSummary) requestWorld().catch(() => {})
+    return () => {
+      socket.off('world.summary', onSummary)
+      socket.off('connect', onConnect)
+    }
+  }, [])
   return summary
 }
+
 export function useWorldSnapshot() {
-  const [snap, setSnap] = useState(null)
-  useEffect(()=>{ const h=(s)=>setSnap(s); socket.on('world.snapshot',h); return ()=>socket.off('world.snapshot',h)},[])
+  const [snap, setSnap] = useState(lastSnapshot)
+  useEffect(() => {
+    const onSnapshot = (s) => { lastSnapshot = s; setSnap(s) }
+    const onConnect = () => requestWorld().catch(() => {})
+    socket.on('world.snapshot', onSnapshot)
+    socket.on('connect', onConnect)
+    if (!lastSnapshot) requestWorld().catch(() => {})
+    return () => {
+      socket.off('world.snapshot', onSnapshot)
+      socket.off('connect', onConnect)
+    }
+  }, [])
   return snap
 }

--- a/apps/client/src/pages/Devices.jsx
+++ b/apps/client/src/pages/Devices.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react'
+import { useWorldSnapshot, requestWorld } from '@/lib/worldControl.js'
+import Table from '@/components/Table.jsx'
+
+export default function DevicesPage() {
+  const snapshot = useWorldSnapshot()
+  useEffect(() => { if (!snapshot) requestWorld().catch(() => {}) }, [snapshot])
+  const rows = []
+  snapshot?.rooms?.forEach((r) => {
+    ;(r.zones || []).forEach((z) => {
+      const blueprints = (z.devices || [])
+        .map((d) => `${d.blueprintId} x ${d.count}`)
+        .join(', ')
+      rows.push({
+        room: r.name || r.id,
+        zone: z.name || z.id,
+        total: z.devicesTotal || 0,
+        blueprints,
+      })
+    })
+  })
+  if (rows.length === 0) return <div style={{ padding: 16 }}>No devices configured</div>
+  return (
+    <div style={{ padding: 16 }}>
+      <h2 style={{ marginTop: 0 }}>Devices</h2>
+      <Table
+        columns={[
+          { key: 'room', label: 'Room' },
+          { key: 'zone', label: 'Zone' },
+          { key: 'total', label: 'Devices Total' },
+          { key: 'blueprints', label: 'Blueprints' },
+        ]}
+        rows={rows}
+      />
+    </div>
+  )
+}

--- a/apps/client/src/pages/Plants.jsx
+++ b/apps/client/src/pages/Plants.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react'
+import { useWorldSnapshot, requestWorld } from '@/lib/worldControl.js'
+import Table from '@/components/Table.jsx'
+
+export default function PlantsPage() {
+  const snapshot = useWorldSnapshot()
+  useEffect(() => { if (!snapshot) requestWorld().catch(() => {}) }, [snapshot])
+  const rows = []
+  snapshot?.rooms?.forEach((r) => {
+    ;(r.zones || []).forEach((z) => {
+      rows.push({
+        room: r.name || r.id,
+        zone: z.name || z.id,
+        strain: z.strainLabel ?? z.strainId ?? '—',
+        method: z.methodLabel ?? z.methodId ?? '—',
+        planned: z.plantsPlanned ?? 0,
+      })
+    })
+  })
+  if (rows.length === 0) return <div style={{ padding: 16 }}>No zones configured</div>
+  return (
+    <div style={{ padding: 16 }}>
+      <h2 style={{ marginTop: 0 }}>Planned Plants</h2>
+      <Table
+        columns={[
+          { key: 'room', label: 'Room' },
+          { key: 'zone', label: 'Zone' },
+          { key: 'strain', label: 'Strain' },
+          { key: 'method', label: 'Method' },
+          { key: 'planned', label: 'Planned Plants' },
+        ]}
+        rows={rows}
+      />
+    </div>
+  )
+}

--- a/apps/client/src/pages/Structure.jsx
+++ b/apps/client/src/pages/Structure.jsx
@@ -1,14 +1,11 @@
-import React, { useEffect } from 'react'
-import { useWorldSummary, useWorldSnapshot, requestWorld } from '@/lib/worldControl.js'
+import React from 'react'
+import { useWorldSummary, useWorldSnapshot } from '@/lib/worldControl.js'
 import { useSimState } from '@/lib/simControl.js'
 
 export default function StructurePage() {
   const summary = useWorldSummary()
   const snapshot = useWorldSnapshot()
   const [sim] = useSimState()
-
-  useEffect(() => { if (!summary || !snapshot) requestWorld().catch(()=>{}) }, [summary, snapshot])
-
   return (
     <div style={wrap}>
       <div style={cardsRow}>
@@ -18,14 +15,12 @@ export default function StructurePage() {
         <Card title="Plants" value={summary?.plants ?? 0} />
         <Card title="Harvests" value={summary?.harvests ?? 0} />
       </div>
-
       <div style={{ marginTop: 16 }}>
-        <TableHeader />
-        <div>
-          {snapshot?.rooms?.length
-            ? snapshot.rooms.map((r) => <RoomRow key={r.id} room={r} />)
-            : <EmptyRow />}
-        </div>
+        {snapshot?.rooms?.length ? (
+          snapshot.rooms.map((r) => <RoomBlock key={r.id} room={r} />)
+        ) : (
+          <EmptyRooms />
+        )}
       </div>
     </div>
   )
@@ -40,59 +35,57 @@ function Card({ title, value }) {
   )
 }
 
-function TableHeader() {
-  return (
-    <div style={thead}>
-      <div style={{ flex: 2 }}>Room</div>
-      <div style={{ flex: 2 }}>Zones</div>
-      <div style={{ flex: 2 }}>Strain</div>
-      <div style={{ flex: 1 }}>Method</div>
-    </div>
-  )
-}
-
-function RoomRow({ room }) {
+function RoomBlock({ room }) {
   const zones = room.zones || []
   return (
+    <div style={{ marginBottom: 24 }}>
+      <div style={{ fontWeight: 600, margin: '8px 4px' }}>{room.name || room.id}</div>
+      <div style={thead}>
+        <div style={{ flex: 2 }}>Zone</div>
+        <div style={{ flex: 2 }}>Strain</div>
+        <div style={{ flex: 1 }}>Method</div>
+        <div style={{ flex: 1 }} />
+      </div>
+      {zones.length ? zones.map((z) => <ZoneRow key={z.id} zone={z} />) : <NoZones />}
+    </div>
+  )
+}
+
+function ZoneRow({ zone }) {
+  return (
     <div style={trow}>
-      <div style={{ flex: 2, fontWeight: 600 }}>{room.name || room.id}</div>
-      <div style={{ flex: 2 }}>
-        {zones.length
-          ? zones.map((z) => (
-              <span key={z.id} style={tag}>
-                {z.name || z.id}
-              </span>
-            ))
-          : <span style={{ opacity: 0.6 }}>—</span>}
-      </div>
-      <div style={{ flex: 2 }}>
-        {zones.length
-          ? zones.map((z) => (
-              <span key={z.id} style={tagSoft}>
-                {z.strainLabel ?? z.strainId ?? '—'}
-              </span>
-            ))
-          : <span style={{ opacity: 0.6 }}>—</span>}
-      </div>
-      <div style={{ flex: 1 }}>
-        {zones.length
-          ? zones.map((z) => (
-              <span key={z.id} style={tagSoft}>
-                {z.methodLabel ?? z.methodId ?? '—'}
-              </span>
-            ))
-          : <span style={{ opacity: 0.6 }}>—</span>}
+      <div style={{ flex: 2 }}>{zone.name || zone.id}</div>
+      <div style={{ flex: 2 }}>{zone.strainLabel ?? zone.strainId ?? '—'}</div>
+      <div style={{ flex: 1 }}>{zone.methodLabel ?? zone.methodId ?? '—'}</div>
+      <div style={{ flex: 1, textAlign: 'right' }}>
+        {Number.isFinite(zone.plantsPlanned) && (
+          <span style={tagSoft}>planned {zone.plantsPlanned}</span>
+        )}
+        {zone.devicesTotal ? (
+          <span style={tagSoft}>devices {zone.devicesTotal}</span>
+        ) : null}
       </div>
     </div>
   )
 }
 
-function EmptyRow() {
+function NoZones() {
+  return (
+    <div style={{ ...trow, opacity: 0.7 }}>
+      <div style={{ flex: 2 }}>—</div>
+      <div style={{ flex: 2 }}>No zones</div>
+      <div style={{ flex: 1 }}>—</div>
+      <div style={{ flex: 1 }}>—</div>
+    </div>
+  )
+}
+
+function EmptyRooms() {
   return (
     <div style={{ ...trow, opacity: 0.7 }}>
       <div style={{ flex: 2 }}>—</div>
       <div style={{ flex: 2 }}>No rooms loaded</div>
-      <div style={{ flex: 2 }}>—</div>
+      <div style={{ flex: 1 }}>—</div>
       <div style={{ flex: 1 }}>—</div>
     </div>
   )
@@ -103,5 +96,12 @@ const cardsRow = { display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 
 const card = { background: '#1b1f2a', padding: 12, borderRadius: 8, border: '1px solid #2b3344' }
 const thead = { display: 'flex', gap: 12, padding: '8px 4px', borderBottom: '1px solid #2b3344', opacity: 0.8 }
 const trow = { display: 'flex', gap: 12, padding: '10px 4px', borderBottom: '1px dashed #2b3344' }
-const tag = { display: 'inline-block', background: '#232a39', border: '1px solid #2b3344', padding: '2px 6px', borderRadius: 8, marginRight: 6 }
-const tagSoft = { ...tag, opacity: 0.9 }
+const tagSoft = {
+  display: 'inline-block',
+  background: '#232a39',
+  border: '1px solid #2b3344',
+  padding: '2px 6px',
+  borderRadius: 8,
+  marginLeft: 6,
+  opacity: 0.9,
+}

--- a/apps/client/src/routes/Router.jsx
+++ b/apps/client/src/routes/Router.jsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import StructurePage from '../pages/Structure.jsx';
 import RoomView from '../views/RoomView.jsx';
 import ZoneView from '../views/ZoneView.jsx';
-import DevicesView from '../views/DevicesView.jsx';
-import PlantsView from '../views/PlantsView.jsx';
+import DevicesPage from '../pages/Devices.jsx';
+import PlantsPage from '../pages/Plants.jsx';
 import StrainsPage from '../pages/Strains.jsx';
 
 /** Simple hash router. */
@@ -26,9 +26,9 @@ export default function Router() {
     View = ZoneView;
     params = { zoneId: mZone[1] };
   } else if (hash.startsWith('#/devices')) {
-    View = DevicesView;
+    View = DevicesPage;
   } else if (hash.startsWith('#/plants')) {
-    View = PlantsView;
+    View = PlantsPage;
   } else if (hash.startsWith('#/strains')) {
     View = StrainsPage;
   }

--- a/src/server/savegame.mjs
+++ b/src/server/savegame.mjs
@@ -52,11 +52,41 @@ export function computeSummary(world) {
   for (const r of rooms) {
     for (const z of r?.zones ?? []) {
       zoneCount++
-      if (Array.isArray(z?.plants)) plantCount += z.plants.length
+      plantCount += estimatePlantsForZone(z)
     }
   }
   const harvests = Number(world?.metrics?.harvests ?? 0)
   return { rooms: roomCount, zones: zoneCount, plants: plantCount, harvests }
+}
+
+export function resolveMethod(id) {
+  const name = `${id}.json`
+  const candidates = [
+    path.resolve(process.cwd(), 'data', 'methods', name),
+    path.resolve(process.cwd(), 'data', 'cultivation_methods', name),
+    path.resolve(process.cwd(), 'data', 'cultivationMethods', name),
+  ]
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try {
+        return JSON.parse(fs.readFileSync(p, 'utf8'))
+      } catch {
+        /* ignore malformed file */
+      }
+    }
+  }
+  return { areaPerPlant: 0.25, containerSpec: { packingDensity: 0.95 } }
+}
+
+export function estimatePlantsForZone(zone) {
+  const sim = zone?.simulation || {}
+  const method = resolveMethod(sim.methodId)
+  const areaPerPlant = Number(method?.areaPerPlant ?? 0.25)
+  const density = Number(method?.containerSpec?.packingDensity ?? 1)
+  const area = Number(zone?.area ?? 0)
+  const effectiveArea = area * (Number.isFinite(density) ? density : 1)
+  const plants = Math.max(0, Math.floor(effectiveArea / Math.max(1e-6, areaPerPlant)))
+  return plants
 }
 
 function humanizeMethod(id) {
@@ -87,18 +117,30 @@ export function computeSnapshot(world) {
           const st = p?.stage
           if (st) counts[st] = (counts[st] || 0) + 1
         }
-        phase = Object.entries(counts).sort((a,b)=>b[1]-a[1])[0]?.[0] || null
+        phase = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] || null
       }
+      const plantsPlanned = estimatePlantsForZone(z)
       const sim = z?.simulation || {}
       const strainId = sim.strainId || null
       const strainLabel = labelFromZoneName(z?.name, strainId)
       const methodId = sim.methodId || null
       const methodLabel = humanizeMethod(methodId)
+      const devices = (z?.devices || []).map((d) => ({
+        blueprintId: d.blueprintId,
+        count: Number(d.count || 0),
+      }))
+      const devicesTotal = devices.reduce((a, d) => a + (d.count || 0), 0)
       const zoneSnap = {
-        id: z.id, name: z.name,
+        id: z.id,
+        name: z.name,
         plantsCount,
-        strainId, strainLabel,
-        methodId, methodLabel,
+        plantsPlanned,
+        strainId,
+        strainLabel,
+        methodId,
+        methodLabel,
+        devices,
+        devicesTotal,
       }
       if (phase) zoneSnap.phase = phase
       return zoneSnap


### PR DESCRIPTION
## Summary
- estimate planned plants per zone via cultivation methods and expose device counts
- cache world state client-side with auto refetch on mount and reconnect
- add Plants and Devices pages and render vertical zone list with planned/devices tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4832a34548325b8fa0e8939c199d4