### PR TITLE
feat(sim+ui): visible harvesting, mini finance footer, and per-zone average stress

### DIFF
--- a/apps/client/src/App.jsx
+++ b/apps/client/src/App.jsx
@@ -5,6 +5,7 @@ import Router from '@/routes/Router.jsx';
 import DevConsole from '@/components/DevConsole.jsx';
 import DevBadge from '@/components/DevBadge.jsx';
 import DevErrorBoundary from '@/components/DevErrorBoundary.jsx';
+import FooterMiniFinance from '@/components/FooterMiniFinance.tsx';
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
       <AppShell>
         <Router />
       </AppShell>
+      <FooterMiniFinance />
       <DevConsole />
       <DevBadge />
     </DevErrorBoundary>

--- a/apps/client/src/components/FooterMiniFinance.tsx
+++ b/apps/client/src/components/FooterMiniFinance.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useSimState } from '@/store/simStore.ts';
+
+/**
+ * Fixed footer showing current cash and daily operating costs.
+ */
+export default function FooterMiniFinance() {
+  const { cash, dailyCosts } = useSimState();
+  const fmt = (v: number) => `฿ ${Math.round(v).toLocaleString()}`;
+  return (
+    <div className="fixed bottom-0 left-0 w-full bg-black/70 text-white text-sm p-2 flex justify-center space-x-4">
+      <span>Cash: {fmt(cash)}</span>
+      <span>Daily Costs: {fmt(dailyCosts)}</span>
+    </div>
+  );
+}

--- a/apps/client/src/store/simStore.ts
+++ b/apps/client/src/store/simStore.ts
@@ -1,0 +1,61 @@
+import { BehaviorSubject } from 'rxjs';
+import { useEffect, useState } from 'react';
+import { socket } from '@/lib/socket.js';
+
+export interface SimState {
+  cash: number;
+  dailyCosts: number;
+  zones: Record<string, { avgStress?: number; totalBiomass_g?: number; totalBuds_g?: number; lastHarvestDay?: number }>;
+}
+
+const initial: SimState = { cash: 0, dailyCosts: 0, zones: {} };
+export const simState$ = new BehaviorSubject<SimState>(initial);
+
+export function applySimDay(payload: any) {
+  const cur = simState$.value;
+  const zones = { ...cur.zones };
+  const day = payload?.day;
+  for (const z of payload?.zoneStats ?? []) {
+    zones[z.zoneId] = {
+      ...(zones[z.zoneId] || {}),
+      avgStress: z.avgStress,
+      totalBiomass_g: z.totalBiomass_g,
+      totalBuds_g: z.totalBuds_g,
+      lastHarvestDay: z.harvestEventsToday > 0 ? day : zones[z.zoneId]?.lastHarvestDay,
+    };
+  }
+  const finance = payload?.finance || {};
+  simState$.next({
+    cash: finance.cash ?? cur.cash,
+    dailyCosts: finance.dailyCosts ?? cur.dailyCosts,
+    zones,
+  });
+}
+
+export function applyFinanceUpdate(payload: any) {
+  const cur = simState$.value;
+  simState$.next({ ...cur, cash: payload?.cash ?? cur.cash });
+}
+
+export function applyHarvestEvent(payload: any) {
+  if (!payload?.zoneId) return;
+  const cur = simState$.value;
+  const zones = { ...cur.zones };
+  const z = zones[payload.zoneId] || {};
+  z.lastHarvestDay = payload.day ?? z.lastHarvestDay;
+  zones[payload.zoneId] = z;
+  simState$.next({ ...cur, zones });
+}
+
+socket.on('sim:day', applySimDay);
+socket.on('finance:update', applyFinanceUpdate);
+socket.on('harvest:event', applyHarvestEvent);
+
+export function useSimState() {
+  const [val, setVal] = useState(simState$.value);
+  useEffect(() => {
+    const s = simState$.subscribe(setVal);
+    return () => s.unsubscribe();
+  }, []);
+  return val;
+}

--- a/apps/client/src/views/ZoneView.jsx
+++ b/apps/client/src/views/ZoneView.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useUiState } from '../store/uiStore.js';
+import { useSimState } from '../store/simStore.ts';
 import {
   fmtCelsius,
   fmtPercent,
@@ -13,6 +14,8 @@ import {
 export default function ZoneView({ zoneId }) {
   const { zones, plants } = useUiState();
   const zone = zones.get(zoneId);
+  const sim = useSimState();
+  const simZone = sim.zones[zoneId] || {};
   const [history, setHistory] = useState([]);
 
   useEffect(() => {
@@ -24,11 +27,19 @@ export default function ZoneView({ zoneId }) {
 
   const plantCount = Array.from(plants.values()).filter((p) => p.zoneId === zoneId).length;
   const points = history.map((v, i) => `${i * 5},${50 - (v || 0)}`).join(' ');
-  const lastHarvest = zone.lastHarvestTs ? new Date(zone.lastHarvestTs).toLocaleString() : 'n/a';
+  const lastHarvest = simZone.lastHarvestDay ? `Day ${simZone.lastHarvestDay}` : 'n/a';
+  const stress = simZone.avgStress ?? 0;
+  let stressColor = 'bg-green-600';
+  if (stress > 75) stressColor = 'bg-red-600';
+  else if (stress > 50) stressColor = 'bg-orange-500';
+  else if (stress > 20) stressColor = 'bg-yellow-500';
 
   return (
     <div>
-      <h2>Zone {zoneId}</h2>
+      <h2>
+        Zone {zoneId}
+        <span className={`ml-2 px-2 py-1 rounded text-white text-xs ${stressColor}`}>{Math.round(stress)}</span>
+      </h2>
       <div>
         Temp: {fmtCelsius(zone.temp_C)} | Humidity: {fmtPercent(zone.humidity_rel)} | CO₂: {fmtPPM(zone.co2_ppm)} | PPFD: {fmtPPFD(zone.ppfd_umol_m2s)}
       </div>

--- a/scripts/audit_last.mjs
+++ b/scripts/audit_last.mjs
@@ -100,6 +100,8 @@ for (const [zoneId, arr] of zoneMap.entries()) {
     harvestEvents,
     firstHarvestDay: isFinite(firstHarvestDay) ? firstHarvestDay : null,
     lastHarvestDay: isFinite(lastHarvestDay) ? lastHarvestDay : null,
+    avgStress_day1: day1?.avgStress ?? null,
+    avgStress_lastDay: lastWithPlants?.avgStress ?? null,
     // BEGIN: REPLANTING v1 (do not remove)
     replantsAttempted,
     replantsSucceeded,

--- a/src/economy/computeDailyCosts.js
+++ b/src/economy/computeDailyCosts.js
@@ -1,0 +1,31 @@
+/**
+ * Compute daily operating costs across all zones/devices.
+ * @module economy/computeDailyCosts
+ */
+
+/**
+ * Compute daily operating costs across all zones/devices (energy, maintenance, water, nutrients).
+ * @param {{costEngine?: any, ticksPerDay?: number}} state
+ * @returns {number} daily costs in EUR
+ */
+export function computeDailyOperatingCosts(state = {}) {
+  const ce = state.costEngine;
+  if (!ce) return 0;
+  const ticksPerDay = Math.max(1, Number(state.ticksPerDay || 24));
+  const hist = Array.isArray(ce.tickHistory) ? ce.tickHistory : [];
+  if (!hist.length) return 0;
+  const slice = hist.slice(-ticksPerDay);
+  let total = 0;
+  for (const t of slice) {
+    total +=
+      (t.energyEUR || 0) +
+      (t.waterEUR || 0) +
+      (t.fertilizerEUR || 0) +
+      (t.maintenanceEUR || 0) +
+      (t.rentEUR || 0) +
+      (t.otherExpenseEUR || 0);
+  }
+  return total;
+}
+
+export default { computeDailyOperatingCosts };

--- a/src/engine/Plant.js
+++ b/src/engine/Plant.js
@@ -423,6 +423,69 @@ export class Plant {
     });
   }
 
+  /**
+   * Returns an integer stress score [0..100].
+   * Falls back to current plant stress state if present.
+   * @param {object} [ctx]
+   * @returns {number}
+   */
+  getStressScore(ctx = {}) {
+    const existing = this.state?.stress?.current;
+    if (Number.isFinite(existing)) {
+      return Math.round(clamp(0, existing, 100));
+    }
+    const raw = Number(this.stress ?? 0);
+    return Math.round(clamp(0, raw * 100, 100));
+  }
+
+  /**
+   * Returns a normalized breakdown [0..1] per component.
+   * Missing components default to 0.
+   * @param {object} [ctx]
+   * @returns {{temp:number,vpd:number,light:number,water:number,nutrients:number,pathogens:number}}
+   */
+  getStressBreakdown(ctx = {}) {
+    const out = { temp: 0, vpd: 0, light: 0, water: 0, nutrients: 0, pathogens: 0 };
+    const src = this.state?.stress?.components || this.stressors || {};
+    out.temp = Number(src.temperature?.severity ?? src.temp ?? 0);
+    out.vpd = Number(src.humidity?.severity ?? src.vpd ?? 0);
+    out.light = Number(src.light?.severity ?? 0);
+    out.water = Number(src.water?.severity ?? 0);
+    out.nutrients = Number(src.nutrients?.severity ?? 0);
+    out.pathogens = Number(src.pathogens?.severity ?? 0);
+    for (const k of Object.keys(out)) {
+      let v = out[k];
+      if (!Number.isFinite(v)) v = 0;
+      out[k] = Math.max(0, Math.min(1, v));
+    }
+    return out;
+  }
+
+  /**
+   * True if the plant meets harvest readiness (maturity window reached, not dead).
+   * Uses existing maturity/age/stage fields; does not hardcode strain names.
+   * @param {object} [ctx]
+   * @returns {boolean}
+   */
+  isHarvestReady(ctx = {}) {
+    if (this.isDead || this._harvested) return false;
+    const stage = String(this.stage || '').toLowerCase();
+    if (stage === 'harvestready') return true;
+    if (stage === 'harvested' || stage === 'dead') return false;
+    const maturity = Number(this.maturity ?? this.state?.maturity ?? this.payload?.maturity ?? 0);
+    if (stage.startsWith('flower') && maturity >= 1) return true;
+    const vegDays = this.strain?.vegDays ?? this.strain?.photoperiod?.vegetationDays;
+    const flowerDays = this.strain?.flowerDays ?? this.strain?.photoperiod?.floweringDays;
+    if (Number.isFinite(this.ageHours) && (vegDays != null || flowerDays != null)) {
+      const total = (Number(vegDays ?? 0) + Number(flowerDays ?? 0));
+      if (total > 0) {
+        const ageDays = this.ageHours / 24;
+        if (ageDays >= total) return true;
+      }
+    }
+    return false;
+  }
+
   /** Idempotent harvest call (executed at most once). */
   harvestOnce(tctx) {
     if (this._harvested) return 0;

--- a/src/engine/Zone.js
+++ b/src/engine/Zone.js
@@ -207,6 +207,25 @@ export class Zone {
     return this.metrics;
   }
 
+  /**
+   * Average plant stress in this zone as integer [0..100].
+   * @param {object} [ctx]
+   * @returns {number}
+   */
+  getAverageStress(ctx = {}) {
+    let sum = 0;
+    let count = 0;
+    for (const p of this.plants ?? []) {
+      if (p?.isDead) continue;
+      const s = p.getStressScore?.(ctx);
+      if (Number.isFinite(s)) {
+        sum += s;
+        count += 1;
+      }
+    }
+    return count > 0 ? Math.round(sum / count) : 0;
+  }
+
   // --- Public Methods ----------------------------------------------------
 
   /**
@@ -317,7 +336,12 @@ export class Zone {
   }
 
   harvestAndInventory(tickIndex) {
-    this.#harvestAndReplant(tickIndex);
+    try {
+      const ready = (this.plants ?? []).some(p => p?.isHarvestReady?.({ tick: tickIndex, zone: this }));
+      if (ready) this.#harvestAndReplant(tickIndex);
+    } catch {
+      /* ignore */
+    }
     this.#replaceBrokenDevices();
   }
 
@@ -490,7 +514,7 @@ export class Zone {
     const ready = [];
     const keep = [];
     for (const p of this.plants) {
-      if (p.stage === 'harvestReady') ready.push(p);
+      if (p?.isHarvestReady?.({ tick: tickIndex, zone: this })) ready.push(p);
       else if (!p.isDead && p.stage !== 'dead') keep.push(p);
     }
     const ticksPerDay = Math.round(24 / this.tickLengthInHours);
@@ -500,10 +524,12 @@ export class Zone {
     if (ready.length === 0) return;
 
     let revenueEUR = 0;
+    let budsDelta = 0;
     const world = this.runtime.world;
     const day = Math.floor(tickIndex / ticksPerDay) + 1;
     for (const plant of ready) {
       const buds = plant.harvestOnce({ day, tick: tickIndex, zoneId: this.id, runId: process.env.RUN_ID });
+      budsDelta += buds;
       const strainId = plant.strain?.id;
       const priceInfo = get(this.strainPriceMap, strainId) ?? {};
       const pricePerGram = Number(priceInfo.harvestPricePerGram ?? priceInfo.pricePerGram ?? 0);
@@ -535,6 +561,7 @@ export class Zone {
         const dayIdx = Math.floor(tickIndex / ticksPerDay);
         if (this.firstHarvestDay == null) this.firstHarvestDay = dayIdx;
         this.lastHarvestDay = dayIdx;
+        emit('harvest:event', { zoneId: this.id, day: dayIdx, plantsHarvested: harvested, buds_g_delta: budsDelta }, tickIndex);
         if (process.env.DEBUG_HARVEST && this.harvestedPlants > 0) {
           console.assert(this.totalBuds_g >= this.harvestedPlants * 0.1, 'totalBuds_g too low');
         }

--- a/src/engine/createEngine.js
+++ b/src/engine/createEngine.js
@@ -18,6 +18,7 @@ import { uiStream$, emit } from '../runtime/eventBus.js';
 import { telemetryAdapter } from '../sim/telemetryAdapter.js';
 import { ensureRng } from '../lib/rng.mjs';
 import { resolveProjectPath } from '../lib/pathutil.mjs';
+import { computeDailyOperatingCosts } from '../economy/computeDailyCosts.js';
 
 /**
  * @typedef {object} Engine
@@ -48,6 +49,8 @@ export function createEngine(opts = {}) {
   let zones = [];
   /** @type {any} */
   let structure = null;
+  /** @type {CostEngine|null} */
+  let costEngine = null;
 
   // bind telemetry adapter to existing runtime/eventBus
   const bus = {
@@ -64,7 +67,7 @@ export function createEngine(opts = {}) {
     const strainPriceMap = await loadStrainPriceMap();
     const blueprints = await loadAllDevices();
 
-    const costEngine = new CostEngine({ devicePriceMap, strainPriceMap });
+    costEngine = new CostEngine({ devicePriceMap, strainPriceMap });
     const world = { totalBuds_g: 0, strainStats: new Map() };
 
     const runtimeBase = { logger, rng: rngWrapped, costEngine, devicePriceMap, strainPriceMap, blueprints, world };
@@ -126,6 +129,9 @@ export function createEngine(opts = {}) {
 
   /** run one simulation tick over all zones */
   async function step() {
+    const ticksPerDay = zones[0] ? Math.round(24 / zones[0].tickLengthInHours) : 24;
+    costEngine?.startTick(tick + 1);
+
     // Simple sequential updates to keep event loop responsive
     for (const z of zones) {
       try {
@@ -139,8 +145,36 @@ export function createEngine(opts = {}) {
     // Optional additional orchestration (e.g., XState) could be wired here
     try { createTickMachine; } catch {}
 
+    const totals = costEngine?.commitTick?.();
+    if (totals) costEngine.recordTickTotals?.(totals);
+
+    emit('finance:update', { cash: costEngine?.getBalance?.() ?? 0 }, tick);
+
     // Telemetry heartbeat
     try { onTick?.(tick); } catch (err) { logger?.warn?.({ err: String(err) }, 'telemetry emit failed'); }
+
+    const dayFrac = (tick % ticksPerDay) / ticksPerDay;
+    emit('sim:tick', { tick, dayFrac }, tick);
+
+    if ((tick + 1) % ticksPerDay === 0) {
+      const day = Math.floor((tick + 1) / ticksPerDay);
+      const zoneStats = zones.map(z => {
+        z.recomputeMetrics?.();
+        const avgStress = z.getAverageStress?.() ?? 0;
+        const eventsToday = (z.harvestEvents - (z._prevHarvestEvents ?? 0));
+        z._prevHarvestEvents = z.harvestEvents;
+        return {
+          zoneId: z.id,
+          avgStress: Math.round(avgStress),
+          totalBiomass_g: z.metrics?.totalBiomass_g ?? 0,
+          totalBuds_g: z.metrics?.totalBuds_g ?? 0,
+          harvestEventsToday: eventsToday,
+        };
+      });
+      const dailyCosts = computeDailyOperatingCosts({ costEngine, ticksPerDay }) || 0;
+      const finance = { cash: costEngine?.getBalance?.() ?? 0, dailyCosts };
+      emit('sim:day', { day, finance, zoneStats }, tick);
+    }
 
     tick += 1;
   }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -13,6 +13,7 @@ import {
   computeSummary,
   computeSnapshot,
 } from './savegame.mjs'
+import { events$ } from '../runtime/eventBus.js'
 
 const PORT = Number(process.env.PORT || 7071)
 const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui'
@@ -66,6 +67,12 @@ function bootstrap() {
 
 bootstrap()
 broadcastWorld()
+
+events$.subscribe((e) => {
+  if (['sim:day','harvest:event','finance:update','sim:tick'].includes(e.type)) {
+    io.emit(e.type, e.payload)
+  }
+})
 
 io.on('connection', (socket) => {
   socket.emit('sim.state', sim.state())


### PR DESCRIPTION
## Summary
- expose plant stress, breakdown, and harvest readiness helpers
- emit harvest events and daily zone/finance snapshots with websocket forwarding
- add finance store with fixed footer and zone stress badge

## Testing
- `npm test`
- `node scripts/audit_last.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b48e8536d88325a7bd1943df91d7ab