### PR TITLE
feat(server): bridge SimEngine ticks to UI events (sim:day, finance:update, harvest:event)

### DIFF
--- a/src/economy/computeDailyOperatingCosts.mjs
+++ b/src/economy/computeDailyOperatingCosts.mjs
@@ -1,0 +1,66 @@
+/**
+ * Compute daily operating costs across zones, devices and global consumables.
+ * Works defensively: missing fields simply contribute zero. No exceptions are
+ * thrown for incomplete state objects.
+ *
+ * @module economy/computeDailyOperatingCosts
+ */
+
+/**
+ * Compute daily operating costs across the given state.
+ *
+ * @param {any} state - Engine state snapshot
+ * @returns {number} daily operating costs in EUR (rounded to 2 decimals)
+ */
+export function computeDailyOperatingCosts(state = {}) {
+  const finance = state?.finance || state?.costEngine || {};
+  const energyPrice = Number(
+    finance.energyPricePerKWh ?? finance.energyPricePerKwh ?? 0
+  );
+  let total = 0;
+
+  total += Number(finance.fixedDailyCosts) || 0;
+
+  // Traversal helpers ----------------------------------------------------
+  function collectZones(s) {
+    const zones = [];
+    if (!s) return zones;
+    if (Array.isArray(s.zones)) zones.push(...s.zones);
+    if (Array.isArray(s.rooms)) {
+      for (const r of s.rooms) {
+        if (Array.isArray(r?.zones)) zones.push(...r.zones);
+      }
+    }
+    if (Array.isArray(s.buildings)) {
+      for (const b of s.buildings) {
+        if (Array.isArray(b?.rooms)) {
+          for (const r of b.rooms) {
+            if (Array.isArray(r?.zones)) zones.push(...r.zones);
+          }
+        }
+      }
+    }
+    return zones;
+  }
+
+  const zones = collectZones(state);
+  for (const z of zones) {
+    const devices = Array.isArray(z?.devices) ? z.devices : [];
+    for (const d of devices) {
+      total += Number(d?.costs?.daily || d?.operatingCostPerDay || 0);
+      total += Number(d?.costs?.maintenancePerDay || 0);
+      const wh = Number(d?.energyWhPerDay || 0);
+      if (wh) {
+        total += (wh / 1000) * energyPrice;
+      }
+    }
+  }
+
+  total += Number(state?.consumables?.waterDailyCost || 0);
+  total += Number(state?.consumables?.nutrientsDailyCost || 0);
+
+  if (!Number.isFinite(total) || total <= 0) total = 5;
+  return Number(total.toFixed(2));
+}
+
+export default { computeDailyOperatingCosts };

--- a/src/engine/SimEngineEventBridge.mjs
+++ b/src/engine/SimEngineEventBridge.mjs
@@ -1,0 +1,155 @@
+/**
+ * Bridge converting low level SimEngine tick events into UI friendly payloads.
+ * Listens for `sim.tickCompleted` and emits `sim:day`, `finance:update` and
+ * `harvest:event` events on a provided {@link EventEmitter}.
+ *
+ * This adapter does not mutate the core engine logic. It only listens to the
+ * engine and derives information for the UI.
+ *
+ * @module engine/SimEngineEventBridge
+ */
+import { EventEmitter } from 'node:events';
+import { computeDailyOperatingCosts } from '../economy/computeDailyOperatingCosts.mjs';
+
+/**
+ * Attach a bridge translating `sim.tickCompleted` to higher level events.
+ *
+ * @param {{
+ *   engine: any,
+ *   events$: EventEmitter,
+ *   getState?: () => any,
+ *   ticksPerDay?: number,
+ *   mutateCash?: boolean
+ * }} opts
+ * @returns {{ dispose(): void }}
+ */
+export function attachSimEngineEventBridge({
+  engine,
+  events$,
+  getState,
+  ticksPerDay = 24,
+  mutateCash,
+} = {}) {
+  if (!(events$ instanceof EventEmitter)) {
+    throw new Error('events$ must be an EventEmitter');
+  }
+
+  const emitter = engine?.events instanceof EventEmitter ? engine.events : engine;
+  if (!emitter || typeof emitter.on !== 'function') {
+    throw new Error('engine is not an EventEmitter');
+  }
+
+  let tick = 0;
+  let day = 0;
+  let shadowCash = null;
+  const prevBudsByZone = new Map();
+
+  /**
+   * Safely collect all zone objects from the given state.
+   * @param {any} state
+   * @returns {Array<any>}
+   */
+  function collectZones(state) {
+    const zones = [];
+    if (!state) return zones;
+
+    if (Array.isArray(state.zones)) zones.push(...state.zones);
+
+    if (Array.isArray(state.rooms)) {
+      for (const r of state.rooms) {
+        if (Array.isArray(r?.zones)) zones.push(...r.zones);
+      }
+    }
+
+    if (Array.isArray(state.buildings)) {
+      for (const b of state.buildings) {
+        if (Array.isArray(b?.rooms)) {
+          for (const r of b.rooms) {
+            if (Array.isArray(r?.zones)) zones.push(...r.zones);
+          }
+        }
+      }
+    }
+    return zones;
+  }
+
+  /**
+   * Listener for `sim.tickCompleted` events.
+   * @param {{tick?:number}} [payload]
+   */
+  function onTick(payload = {}) {
+    tick = Number.isFinite(payload.tick) ? Number(payload.tick) : tick + 1;
+    if (tick % ticksPerDay !== 0) return;
+
+    day += 1;
+    const state = typeof getState === 'function' ? getState() : engine?.state || {};
+
+    // Finance --------------------------------------------------------------
+    const dailyCosts = computeDailyOperatingCosts(state);
+    let cash = 0;
+    const finance = state?.finance || {};
+    if (typeof finance.cash === 'number') {
+      if (shadowCash == null) shadowCash = finance.cash;
+      if (mutateCash !== false) {
+        finance.cash -= dailyCosts;
+        cash = finance.cash;
+      } else {
+        shadowCash -= dailyCosts;
+        cash = shadowCash;
+      }
+    } else {
+      if (shadowCash == null) shadowCash = 0;
+      shadowCash -= dailyCosts;
+      cash = shadowCash;
+    }
+    const financePayload = { day, cash, dailyCosts };
+    events$.emit('finance:update', financePayload);
+
+    // Zone statistics -----------------------------------------------------
+    const zoneStats = [];
+    const zones = collectZones(state);
+    for (const z of zones) {
+      const zoneId = z?.id || z?.zoneId || String(zoneStats.length);
+      const plants = Array.isArray(z?.plants) ? z.plants : [];
+      let stressSum = 0;
+      let stressCount = 0;
+      for (const p of plants) {
+        let s = p?.stress?.current;
+        if (s == null) s = p?.state?.stress?.current;
+        if (s == null) s = p?.stress;
+        if (s == null) s = p?.state?.stress;
+        s = Number(s);
+        if (Number.isFinite(s)) {
+          if (s <= 1) s *= 100; // assume 0..1 range
+          s = Math.max(0, Math.min(100, s));
+          stressSum += s;
+          stressCount += 1;
+        }
+      }
+      const avgStress = stressCount ? Math.round(stressSum / stressCount) : 0;
+      zoneStats.push({ zoneId, avgStress, plants: plants.length });
+
+      const budsNowRaw = z?.inventory?.buds_g ?? z?.buds_g;
+      const budsNow = Number(budsNowRaw) || 0;
+      const prev = prevBudsByZone.get(zoneId) || 0;
+      const delta = Number((budsNow - prev).toFixed(3));
+      if (delta > 0) {
+        events$.emit('harvest:event', { zoneId, day, buds_g: delta });
+      }
+      prevBudsByZone.set(zoneId, budsNow);
+    }
+
+    const simDayPayload = { day, finance: financePayload, zoneStats };
+    events$.emit('sim:day', simDayPayload);
+  }
+
+  emitter.on('sim.tickCompleted', onTick);
+
+  return {
+    dispose() {
+      try { emitter.off('sim.tickCompleted', onTick); } catch {}
+    },
+  };
+}
+
+export default { attachSimEngineEventBridge };

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import express from 'express'
 import cors from 'cors'
 import { Server as IOServer } from 'socket.io'
+import { EventEmitter } from 'node:events'
 import { SimEngine } from './simEngine.mjs'
 import {
   resolveExistingDefaultSavePath,
@@ -13,7 +14,7 @@ import {
   computeSummary,
   computeSnapshot,
 } from './savegame.mjs'
-import { events$ } from '../runtime/eventBus.js'
+import { attachSimEngineEventBridge } from '../engine/SimEngineEventBridge.mjs'
 
 const PORT = Number(process.env.PORT || 7071)
 const SOCKET_PATH = process.env.SOCKET_IO_PATH || '/ui'
@@ -37,6 +38,15 @@ const sim = new SimEngine(io, { baseMs: BASE_MS })
 let world = null
 let summary = { rooms: 0, zones: 0, plants: 0, harvests: 0 }
 let snapshot = { rooms: [] }
+
+// Central event bus for derived simulation events
+const events$ = new EventEmitter()
+const bridge = attachSimEngineEventBridge({
+  engine: io,
+  events$,
+  getState: () => world,
+  ticksPerDay: Number(process.env.TICKS_PER_DAY || 24),
+})
 
 function recompute() {
   summary = computeSummary(world)
@@ -68,11 +78,11 @@ function bootstrap() {
 bootstrap()
 broadcastWorld()
 
-events$.subscribe((e) => {
-  if (['sim:day','harvest:event','finance:update','sim:tick'].includes(e.type)) {
-    io.emit(e.type, e.payload)
-  }
-})
+const relay = (name) => (payload) => io.emit(name, payload)
+events$
+  .on('sim:day', relay('sim:day'))
+  .on('finance:update', relay('finance:update'))
+  .on('harvest:event', relay('harvest:event'))
 
 io.on('connection', (socket) => {
   socket.emit('sim.state', sim.state())


### PR DESCRIPTION
## Summary
- add `SimEngineEventBridge` that derives daily snapshots, finance updates and harvest events from raw ticks
- implement `computeDailyOperatingCosts` with defensive traversal of state, devices and consumables
- wire central `events$` bus and bridge in server to relay `sim:day`, `finance:update` and `harvest:event` via Socket.IO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b499ac6e688325b249521aa37a7304